### PR TITLE
Expose BSP triangle data and fix imports

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -6,11 +6,13 @@ use three_d::*;
 
 // ---------------- BSP Implementation -------------------------------------- //
 
+const MAX_DEPTH: u32 = 16;
+
 #[derive(Clone, Debug)]
 pub struct Triangle {
-    a: Vector3<f32>,
-    b: Vector3<f32>,
-    c: Vector3<f32>,
+    pub a: Vector3<f32>,
+    pub b: Vector3<f32>,
+    pub c: Vector3<f32>,
 }
 
 #[derive(Clone, Debug)]
@@ -280,7 +282,6 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
 
 // Upravená funkce build_bsp, která přiřazuje ID uzlům
 pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> BspNode {
-pub     const MAX_DEPTH: u32 = 16;
     const MIN_TRIANGLES: usize = 20;
 
     let my_id = *next_id;

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -2,6 +2,7 @@
 // Camera utilities
 
 use cgmath::{Vector3, Deg};
+use std::f32::consts::FRAC_PI_2;
 use three_d::*;
 use crate::input::{InputManager, KeyCode};
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use cgmath::Vector3;
+use cgmath::InnerSpace;
 use three_d::*;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
## Summary
- add FRAC_PI_2 import for camera utilities
- enable magnitude2/normalize in `input.rs`
- expose `Triangle` fields and pull MAX_DEPTH constant out of `build_bsp`

## Testing
- `cargo check` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d170cbfb8832fb605b7039489d937

## Summary by Sourcery

Expose BSP triangle data by making its fields public, centralize the MAX_DEPTH constant, add missing FRAC_PI_2 import for camera utilities, and enable magnitude2 and normalize functions in input utilities.

Enhancements:
- Make Triangle struct fields (a, b, c) public for external access
- Move MAX_DEPTH constant out of build_bsp into module scope
- Add FRAC_PI_2 import in camera utilities
- Enable use of magnitude2 and normalize in input utilities