### PR TITLE
Fix compile errors by making BSP data public

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -17,8 +17,8 @@ pub struct Triangle {
 
 #[derive(Clone, Debug)]
 pub struct Plane {
-    n: Vector3<f32>,  // normála
-    d: f32,           // vzdálenost od počátku (ax+by+cz+d=0)
+    pub n: Vector3<f32>,  // normála
+    pub d: f32,           // vzdálenost od počátku (ax+by+cz+d=0)
 }
 
 impl Plane {
@@ -45,26 +45,26 @@ impl Plane {
 
 #[derive(Debug)]
 pub struct BspNode {
-    id: usize,
-    plane: Option<Plane>,
-    front: Option<Box<BspNode>>,
-    back: Option<Box<BspNode>>,
-    triangles: Vec<Triangle>,
-    bounds: BoundingBox,
+    pub id: usize,
+    pub plane: Option<Plane>,
+    pub front: Option<Box<BspNode>>,
+    pub back: Option<Box<BspNode>>,
+    pub triangles: Vec<Triangle>,
+    pub bounds: BoundingBox,
     node_count: u32, // Cache the total number of nodes in this subtree
     subtree_tris: u32, // Cache the total number of triangles in this subtree
 }
 
 #[derive(Default)]
 pub struct BspStats {
-    nodes_visited: u32,
-    triangles_rendered: u32,
-    total_nodes: u32,
-    total_triangles: u32,
+    pub nodes_visited: u32,
+    pub triangles_rendered: u32,
+    pub total_nodes: u32,
+    pub total_triangles: u32,
 }
 
 impl BspNode {
-    fn new_leaf(triangles: Vec<Triangle>, id: usize) -> Self {
+    pub fn new_leaf(triangles: Vec<Triangle>, id: usize) -> Self {
         Self {
             id,
             plane: None,
@@ -97,7 +97,7 @@ impl BspNode {
         }
     }
 
-    fn count_nodes(&self) -> u32 {
+    pub fn count_nodes(&self) -> u32 {
         1 + self.front.as_ref().map_or(0, |n| n.count_nodes()) + 
             self.back.as_ref().map_or(0, |n| n.count_nodes())
     }
@@ -136,7 +136,7 @@ impl Vector3Ext<f32> for Vector3<f32> {
     }
 }
 
-fn triangle_center(tri: &Triangle) -> Vector3<f32> {
+pub fn triangle_center(tri: &Triangle) -> Vector3<f32> {
     (tri.a + tri.b + tri.c) / 3.0
 }
 
@@ -707,9 +707,10 @@ fn create_direction_ray(context: &Context, position: Vector3<f32>, direction: Ve
     direction_ray
 }
 
+#[derive(Clone, Debug)]
 pub struct BoundingBox {
-    min: Vector3<f32>,
-    max: Vector3<f32>,
+    pub min: Vector3<f32>,
+    pub max: Vector3<f32>,
 }
 
 impl BoundingBox {
@@ -796,7 +797,7 @@ pub struct Frustum {
 }
 
 impl Frustum {
-    fn from_camera(camera: &Camera) -> Self {
+    pub fn from_camera(camera: &Camera) -> Self {
         // Získáme view-projection matici
         let vp_matrix = camera.projection() * camera.view();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use rayon::prelude::*; // Add Rayon prelude for parallelization
 mod gpu_job;
 use crate::input::{InputManager, KeyCode};
 use crate::camera::{FreeCamera, CamMode, CameraState, SwitchDelay};
-use crate::bsp::{BspNode, BspStats, Triangle, Frustum, build_bsp, find_node, find_node_path, collect_triangles_in_subtree, create_plane_mesh, create_highlight_mesh, cpu_mesh_to_triangles, traverse_bsp_with_frustum};
+use crate::bsp::{BspNode, BspStats, Triangle, Frustum, build_bsp, find_node, collect_triangles_in_subtree, create_plane_mesh, create_highlight_mesh, cpu_mesh_to_triangles, traverse_bsp_with_frustum, render_bsp_tree, triangle_center};
 
 mod input;
 mod camera;


### PR DESCRIPTION
## Summary
- expose several BSP structs and helper functions
- update imports in `main.rs`
- derive `Clone` and `Debug` for `BoundingBox`

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686d1ad0c864832fb69c4b822f7b1327

## Summary by Sourcery

Expose BSP internal data by marking essential structs, fields, and helper methods as public to fix compilation errors, and adjust imports in main.rs accordingly.

Bug Fixes:
- Make Plane, BspNode, BspStats, and BoundingBox fields public and expose key methods (new_leaf, count_nodes, from_camera, triangle_center).
- Derive Clone and Debug for BoundingBox.
- Update main.rs imports to reference the newly public BSP items and remove outdated references.