### PR TITLE
Add GPU frustum culling

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -874,4 +874,15 @@ impl Frustum {
             planes: [left, right, bottom, top, near, far],
         }
     }
+
+    pub fn as_vec4_array(&self) -> [[f32; 4]; 6] {
+        [
+            [self.planes[0].n.x, self.planes[0].n.y, self.planes[0].n.z, self.planes[0].d],
+            [self.planes[1].n.x, self.planes[1].n.y, self.planes[1].n.z, self.planes[1].d],
+            [self.planes[2].n.x, self.planes[2].n.y, self.planes[2].n.z, self.planes[2].d],
+            [self.planes[3].n.x, self.planes[3].n.y, self.planes[3].n.z, self.planes[3].d],
+            [self.planes[4].n.x, self.planes[4].n.y, self.planes[4].n.z, self.planes[4].d],
+            [self.planes[5].n.x, self.planes[5].n.y, self.planes[5].n.z, self.planes[5].d],
+        ]
+    }
 }

--- a/src/gpu_job.rs
+++ b/src/gpu_job.rs
@@ -3,11 +3,17 @@ use glow::HasContext;
 pub struct GpuJob {
     pub gl: std::sync::Arc<glow::Context>,
     pub prog: glow::NativeProgram,
-    pub ssbo: glow::NativeBuffer,
+    pub in_buffer: glow::NativeBuffer,
+    pub out_buffer: glow::NativeBuffer,
 }
 
 impl GpuJob {
-    pub unsafe fn new(gl: &std::sync::Arc<glow::Context>, src: &str, ssbo_size: usize) -> Self {
+    pub unsafe fn new(
+        gl: &std::sync::Arc<glow::Context>,
+        src: &str,
+        in_size: usize,
+        out_size: usize,
+    ) -> Self {
         let cs = gl.create_shader(glow::COMPUTE_SHADER).unwrap();
         gl.shader_source(cs, src);
         gl.compile_shader(cs);
@@ -18,28 +24,43 @@ impl GpuJob {
         gl.link_program(prog);
         assert!(gl.get_program_link_status(prog));
 
-        let ssbo = gl.create_buffer().unwrap();
-        gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(ssbo));
-        gl.buffer_data_size(glow::SHADER_STORAGE_BUFFER, ssbo_size as i32, glow::DYNAMIC_DRAW);
+        let in_buffer = gl.create_buffer().unwrap();
+        gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(in_buffer));
+        gl.buffer_data_size(glow::SHADER_STORAGE_BUFFER, in_size as i32, glow::DYNAMIC_DRAW);
 
-        Self { gl: gl.clone(), prog, ssbo }
+        let out_buffer = gl.create_buffer().unwrap();
+        gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(out_buffer));
+        gl.buffer_data_size(glow::SHADER_STORAGE_BUFFER, out_size as i32, glow::DYNAMIC_DRAW);
+
+        Self {
+            gl: gl.clone(),
+            prog,
+            in_buffer,
+            out_buffer,
+        }
     }
 
     pub unsafe fn dispatch(&self, x: u32, y: u32, z: u32) {
         self.gl.use_program(Some(self.prog));
+        self
+            .gl
+            .bind_buffer_base(glow::SHADER_STORAGE_BUFFER, 0, Some(self.in_buffer));
+        self
+            .gl
+            .bind_buffer_base(glow::SHADER_STORAGE_BUFFER, 1, Some(self.out_buffer));
         self.gl.dispatch_compute(x, y, z);
         self.gl.memory_barrier(glow::SHADER_STORAGE_BARRIER_BIT);
     }
 
     pub unsafe fn read_ssbo_u8(&self, size: usize) -> Vec<u8> {
-        self.gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(self.ssbo));
+        self.gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(self.out_buffer));
         let mut data = vec![0u8; size];
         self.gl.get_buffer_sub_data(glow::SHADER_STORAGE_BUFFER, 0, &mut data);
         data
     }
 
     pub unsafe fn update_ssbo_data(&self, data: &[u8]) {
-        self.gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(self.ssbo));
+        self.gl.bind_buffer(glow::SHADER_STORAGE_BUFFER, Some(self.in_buffer));
         self.gl.buffer_sub_data_u8_slice(glow::SHADER_STORAGE_BUFFER, 0, data);
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -13,6 +13,7 @@ pub fn draw_left_panel(
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
     disable_culling: &mut bool,
+    use_gpu_culling: &mut bool,
     show_camera_direction: &mut bool,
     spectator_state: &mut crate::camera::CameraState,
     third_person_state: &mut crate::camera::CameraState,
@@ -85,6 +86,7 @@ pub fn draw_left_panel(
             if *disable_culling {
                 ui.label("Varování: Zobrazení celého stromu může zpomalit vykreslování.");
             }
+            ui.checkbox(use_gpu_culling, "Použít GPU culling");
 
             egui::ScrollArea::vertical().show(ui, |ui| {
                 let root = bsp_root.as_ref().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ use three_d::*;
 use rayon::prelude::*; // Add Rayon prelude for parallelization
 
 mod gpu_job;
+mod shaders;
+use crate::gpu_job::GpuJob;
 use crate::input::{InputManager, KeyCode};
 use crate::camera::{FreeCamera, CamMode, CameraState, SwitchDelay};
 use crate::bsp::{BspNode, BspStats, Triangle, Frustum, build_bsp, find_node, collect_triangles_in_subtree, create_plane_mesh, create_highlight_mesh, cpu_mesh_to_triangles, traverse_bsp_with_frustum, triangle_center};
@@ -272,6 +274,44 @@ fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, Co
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
 
+fn gpu_cull_triangles(job: &GpuJob, tris: &[Triangle], frustum: &Frustum) -> Vec<Triangle> {
+    let mut bytes = Vec::with_capacity(tris.len() * 3 * 16);
+    for t in tris {
+        for v in [&t.a, &t.b, &t.c] {
+            bytes.extend_from_slice(&v.x.to_ne_bytes());
+            bytes.extend_from_slice(&v.y.to_ne_bytes());
+            bytes.extend_from_slice(&v.z.to_ne_bytes());
+            bytes.extend_from_slice(&1f32.to_ne_bytes());
+        }
+    }
+    unsafe { job.update_ssbo_data(&bytes); }
+
+    let planes = frustum.as_vec4_array();
+    let mut flat = [0f32; 24];
+    for (i, p) in planes.iter().enumerate() {
+        flat[i * 4] = p[0];
+        flat[i * 4 + 1] = p[1];
+        flat[i * 4 + 2] = p[2];
+        flat[i * 4 + 3] = p[3];
+    }
+    unsafe {
+        let loc = job.gl.get_uniform_location(job.prog, "frustum").unwrap();
+        job.gl.use_program(Some(job.prog));
+        job.gl.uniform_4_f32_slice(Some(&loc), &flat);
+        let groups = ((tris.len() as u32) + 63) / 64;
+        job.dispatch(groups, 1, 1);
+    }
+    let out = unsafe { job.read_ssbo_u8(tris.len() * 4) };
+    let mut result = Vec::new();
+    for (i, chunk) in out.chunks_exact(4).enumerate() {
+        let flag = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        if flag != 0 {
+            result.push(tris[i].clone());
+        }
+    }
+    result
+}
+
 // ---------------- Main --------------------------------------------------- //
 
 fn main() -> Result<()> {
@@ -310,6 +350,17 @@ fn main() -> Result<()> {
     let triangles = cpu_mesh_to_triangles(&cpu_mesh);
     println!("✓ Převedeno {} trojúhelníků", triangles.len());
 
+    // Inicializace GPU jobu pro frustum culling
+    unsafe {
+        let gl = &*context;
+        gpu_job = Some(GpuJob::new(
+            gl,
+            shaders::CULL_SHADER,
+            triangles.len() * 3 * 16,
+            triangles.len() * 4,
+        ));
+    }
+
     // Asynchronní stavba BSP stromu na pozadí
     println!("🌳 Spouštím stavbu BSP stromu na pozadí...");
     let mut bsp_root: Option<BspNode> = None;
@@ -336,6 +387,9 @@ fn main() -> Result<()> {
 
     // Přidáme novou proměnnou pro vypnutí cullingu
     let mut disable_culling = false;
+    // Volba pro GPU akceleraci frustum cullingu
+    let mut use_gpu_culling = false;
+    let mut gpu_job: Option<GpuJob> = None;
 
     // stav pro vykreslovaný mesh
     let _glb_path: Option<PathBuf> = None;
@@ -428,6 +482,15 @@ fn main() -> Result<()> {
                     bsp_root = Some(bsp_tree);
                     total_stats.total_nodes = bsp_root.as_ref().unwrap().count_nodes();
                     total_stats.total_triangles = current_triangles.len() as u32;
+                    unsafe {
+                        let gl = &*context;
+                        gpu_job = Some(GpuJob::new(
+                            gl,
+                            shaders::CULL_SHADER,
+                            current_triangles.len() * 3 * 16,
+                            current_triangles.len() * 4,
+                        ));
+                    }
                     println!("✅ Nový model a BSP strom načteny!");
                 }
             }
@@ -475,22 +538,28 @@ fn main() -> Result<()> {
             ..Default::default()
         };
 
-        // CPU culling - použijeme původní CPU implementaci nebo zobrazíme vše
-        let mut cpu_visible_triangles = Vec::new();
-        if disable_culling {
-            // Když je culling vypnutý, sbíráme všechny trojúhelníky
+        // Výběr culling metody
+        let visible_triangles = if disable_culling {
+            let mut tris = Vec::new();
             if let Some(ref root) = bsp_root {
-                collect_triangles_in_subtree(root, &mut cpu_visible_triangles);
+                collect_triangles_in_subtree(root, &mut tris);
                 current_stats.nodes_visited = current_stats.total_nodes;
                 current_stats.triangles_rendered = current_stats.total_triangles;
             }
-        } else {
-            // Běžné culling chování
-            if let Some(ref root) = bsp_root {
-                traverse_bsp_with_frustum(root, observer_position, &frustum, &mut current_stats, &mut cpu_visible_triangles);
+            tris
+        } else if use_gpu_culling {
+            if let Some(ref job) = gpu_job {
+                gpu_cull_triangles(job, &current_triangles, &frustum)
+            } else {
+                Vec::new()
             }
-        }
-        let visible_triangles = cpu_visible_triangles;
+        } else {
+            let mut tris = Vec::new();
+            if let Some(ref root) = bsp_root {
+                traverse_bsp_with_frustum(root, observer_position, &frustum, &mut current_stats, &mut tris);
+            }
+            tris
+        };
 
         // 1) Shromáždění trojúhelníků z vybraného podstromu
         let mut picked_tris = Vec::new();
@@ -544,6 +613,7 @@ fn main() -> Result<()> {
                 &mut selected_node,
                 &mut show_splitting_plane,
                 &mut disable_culling,
+                &mut use_gpu_culling,
                 &mut show_camera_direction,
                 &mut spectator_state,
                 &mut third_person_state,

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -1,0 +1,33 @@
+pub const CULL_SHADER: &str = r#"
+#version 430
+layout(local_size_x = 64) in;
+
+layout(std430, binding = 0) readonly buffer InTris {
+    vec4 vertices[];
+};
+
+layout(std430, binding = 1) writeonly buffer OutFlags {
+    uint visible[];
+};
+
+uniform vec4 frustum[6];
+
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    uint base = idx * 3u;
+    vec3 a = vertices[base].xyz;
+    vec3 b = vertices[base + 1u].xyz;
+    vec3 c = vertices[base + 2u].xyz;
+    bool inside = true;
+    for(int i = 0; i < 6; ++i) {
+        vec4 p = frustum[i];
+        if(dot(p.xyz, a) + p.w < 0.0 &&
+           dot(p.xyz, b) + p.w < 0.0 &&
+           dot(p.xyz, c) + p.w < 0.0) {
+            inside = false;
+            break;
+        }
+    }
+    visible[idx] = inside ? 1u : 0u;
+}
+"#;


### PR DESCRIPTION
## Summary
- support compute shaders through `GpuJob` with separate input/output buffers
- add GLSL compute shader for GPU triangle culling
- expose `use_gpu_culling` flag in GUI
- hook GPU culling into the main render loop

## Testing
- `cargo check` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2660df24832f9ab380e4075cad22

## Summary by Sourcery

Enable optional GPU-accelerated frustum culling by integrating a compute shader pipeline into the render loop and exposing a corresponding GUI toggle.

New Features:
- Add GPU-based frustum culling using compute shaders
- Expose a GUI checkbox to toggle GPU culling

Enhancements:
- Introduce a GpuJob abstraction with separate input/output SSBOs
- Extend the culling selection logic to support disabled, CPU, or GPU paths
- Add Frustum::as_vec4_array to serialize plane data for the shader