### PR TITLE
Fix GPU culling barriers and speed up disable-culling mode

### DIFF
--- a/src/gpu_job.rs
+++ b/src/gpu_job.rs
@@ -49,7 +49,10 @@ impl GpuJob {
             .gl
             .bind_buffer_base(glow::SHADER_STORAGE_BUFFER, 1, Some(self.out_buffer));
         self.gl.dispatch_compute(x, y, z);
-        self.gl.memory_barrier(glow::SHADER_STORAGE_BARRIER_BIT);
+        // Ensure compute writes are visible when reading the buffer on CPU
+        self.gl.memory_barrier(
+            glow::SHADER_STORAGE_BARRIER_BIT | glow::BUFFER_UPDATE_BARRIER_BIT,
+        );
     }
 
     pub unsafe fn read_ssbo_u8(&self, size: usize) -> Vec<u8> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,13 +542,11 @@ fn main() -> Result<()> {
 
         // Výběr culling metody
         let visible_triangles = if disable_culling {
-            let mut tris = Vec::new();
-            if let Some(ref root) = bsp_root {
-                collect_triangles_in_subtree(root, &mut tris);
-                current_stats.nodes_visited = current_stats.total_nodes;
-                current_stats.triangles_rendered = current_stats.total_triangles;
-            }
-            tris
+            // If culling is disabled, render all triangles without traversing
+            // the BSP tree each frame.
+            current_stats.nodes_visited = current_stats.total_nodes;
+            current_stats.triangles_rendered = current_stats.total_triangles;
+            current_triangles.clone()
         } else if use_gpu_culling {
             if let Some(ref job) = gpu_job {
                 gpu_cull_triangles(job, &current_triangles, &frustum)


### PR DESCRIPTION
## Summary
- ensure compute shader writes are visible before reading SSBOs
- avoid expensive BSP traversal when culling is disabled

## Testing
- `cargo check -q`


------
https://chatgpt.com/codex/tasks/task_e_686d3180ecc4832fbb50f1a54d0375d6

## Summary by Sourcery

Ensure compute shader outputs are synchronized before CPU-side SSBO reads and speed up disable-culling mode by avoiding costly BSP traversal.

Bug Fixes:
- Add BUFFER_UPDATE_BARRIER_BIT to memory_barrier calls to guarantee compute shader writes are visible before reading SSBOs.

Enhancements:
- Optimize disable-culling mode by cloning the current triangle list instead of traversing the BSP tree each frame.