### PR TITLE
Implement map hiding and click selection

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -345,6 +345,23 @@ pub fn find_node_path<'a>(node: &'a BspNode, target_id: usize, path: &mut Vec<&'
     false
 }
 
+pub fn find_deepest_node_containing_point<'a>(node: &'a BspNode, point: Vector3<f32>) -> Option<&'a BspNode> {
+    if !node.bounds.contains(point) {
+        return None;
+    }
+    if let Some(ref front) = node.front {
+        if let Some(n) = find_deepest_node_containing_point(front, point) {
+            return Some(n);
+        }
+    }
+    if let Some(ref back) = node.back {
+        if let Some(n) = find_deepest_node_containing_point(back, point) {
+            return Some(n);
+        }
+    }
+    Some(node)
+}
+
 // Funkce pro rekurzivní vykreslení stromu v UI a zpracování výběru uzlu
 pub fn render_bsp_tree(ui: &mut egui::Ui, node: &BspNode, selected: &mut Option<usize>) {
     // build the label
@@ -719,6 +736,12 @@ impl BoundingBox {
             min: Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY),
             max: Vector3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY),
         }
+    }
+
+    pub fn contains(&self, point: Vector3<f32>) -> bool {
+        point.x >= self.min.x && point.x <= self.max.x &&
+        point.y >= self.min.y && point.y <= self.max.y &&
+        point.z >= self.min.z && point.z <= self.max.z
     }
 
     fn from_triangle(tri: &Triangle) -> Self {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -14,6 +14,7 @@ pub fn draw_left_panel(
     show_splitting_plane: &mut bool,
     disable_culling: &mut bool,
     use_gpu_culling: &mut bool,
+    hide_selected: &mut bool,
     show_camera_direction: &mut bool,
     spectator_state: &mut crate::camera::CameraState,
     third_person_state: &mut crate::camera::CameraState,
@@ -87,6 +88,7 @@ pub fn draw_left_panel(
                 ui.label("Varování: Zobrazení celého stromu může zpomalit vykreslování.");
             }
             ui.checkbox(use_gpu_culling, "Použít GPU culling");
+            ui.checkbox(hide_selected, "Skrýt vybranou oblast");
 
             egui::ScrollArea::vertical().show(ui, |ui| {
                 let root = bsp_root.as_ref().unwrap();


### PR DESCRIPTION
## Summary
- add `BoundingBox::contains` and helper to find node containing a point
- allow hiding selected area through GUI checkbox
- implement mouse picking to select nodes

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68702ba97f40832f8b1fcb9bb6e37b63

## Summary by Sourcery

Implement interactive map hiding and click-based node selection in the BSP viewer.

New Features:
- Enable selecting BSP nodes by clicking in the 3D view using mouse picking.
- Add a GUI checkbox to toggle hiding the selected area in the rendered mesh.

Enhancements:
- Add BoundingBox.contains and find_deepest_node_containing_point to locate BSP nodes by point.
- Adjust triangle filtering and highlighting logic to respect the hide-selected-area toggle.