### PR TITLE
Add configurable rendering colors and picking docs

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -4,9 +4,10 @@ use cgmath::Vector3;
 use rayon::prelude::*;
 use three_d::*;
 
-// ---------------- BSP Implementation -------------------------------------- //
+// Configuration values (colors and tree limits)
+use crate::config::{HIGHLIGHT_COLOR, MAX_BSP_DEPTH, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
 
-const MAX_DEPTH: u32 = 16;
+// ---------------- BSP Implementation -------------------------------------- //
 
 #[derive(Clone, Debug)]
 pub struct Triangle {
@@ -17,8 +18,8 @@ pub struct Triangle {
 
 #[derive(Clone, Debug)]
 pub struct Plane {
-    pub n: Vector3<f32>,  // normála
-    pub d: f32,           // vzdálenost od počátku (ax+by+cz+d=0)
+    pub n: Vector3<f32>, // normála
+    pub d: f32,          // vzdálenost od počátku (ax+by+cz+d=0)
 }
 
 impl Plane {
@@ -36,9 +37,9 @@ impl Plane {
         let dist = self.side(point);
         const EPSILON: f32 = 1e-6;
         match dist {
-            d if d > EPSILON => 1,     // front
-            d if d < -EPSILON => -1,   // back
-            _ => 0,                    // on plane
+            d if d > EPSILON => 1,   // front
+            d if d < -EPSILON => -1, // back
+            _ => 0,                  // on plane
         }
     }
 }
@@ -51,7 +52,7 @@ pub struct BspNode {
     pub back: Option<Box<BspNode>>,
     pub triangles: Vec<Triangle>,
     pub bounds: BoundingBox,
-    node_count: u32, // Cache the total number of nodes in this subtree
+    node_count: u32,   // Cache the total number of nodes in this subtree
     subtree_tris: u32, // Cache the total number of triangles in this subtree
 }
 
@@ -72,7 +73,7 @@ impl BspNode {
             back: None,
             triangles: triangles.clone(),
             bounds: BoundingBox::from_triangles(&triangles),
-            node_count: 1, // Leaf nodes count as 1
+            node_count: 1,                        // Leaf nodes count as 1
             subtree_tris: triangles.len() as u32, // Cache the triangle count
         }
     }
@@ -81,7 +82,7 @@ impl BspNode {
         // Calculate the node count and triangle count before moving the nodes into boxes
         let total_count = 1 + front.node_count + back.node_count;
         let total_tris = front.subtree_tris + back.subtree_tris;
-        
+
         // Nejprve vytvoříme společný obalový objem, než přesuneme hodnoty do boxů
         let bounds = BoundingBox::encompass(&front.bounds, &back.bounds);
 
@@ -92,20 +93,20 @@ impl BspNode {
             back: Some(Box::new(back)),
             triangles: Vec::new(),
             bounds,
-            node_count: total_count, // Use the cached count
+            node_count: total_count,  // Use the cached count
             subtree_tris: total_tris, // Cache the total triangle count in subtree
         }
     }
 
     pub fn count_nodes(&self) -> u32 {
-        1 + self.front.as_ref().map_or(0, |n| n.count_nodes()) + 
-            self.back.as_ref().map_or(0, |n| n.count_nodes())
+        1 + self.front.as_ref().map_or(0, |n| n.count_nodes())
+            + self.back.as_ref().map_or(0, |n| n.count_nodes())
     }
 
     fn count_triangles(&self) -> u32 {
-        self.triangles.len() as u32 + 
-        self.front.as_ref().map_or(0, |n| n.count_triangles()) +
-        self.back.as_ref().map_or(0, |n| n.count_triangles())
+        self.triangles.len() as u32
+            + self.front.as_ref().map_or(0, |n| n.count_triangles())
+            + self.back.as_ref().map_or(0, |n| n.count_triangles())
     }
 }
 
@@ -128,11 +129,7 @@ impl Vector3Ext<f32> for Vector3<f32> {
     where
         F: Fn(f32, f32) -> f32,
     {
-        Vector3::new(
-            f(self.x, other.x),
-            f(self.y, other.y),
-            f(self.z, other.z),
-        )
+        Vector3::new(f(self.x, other.x), f(self.y, other.y), f(self.z, other.z))
     }
 }
 
@@ -171,9 +168,13 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
     }
 
     // 3) Výběr osy podle největší extent
-    let axis = if extent.x >= extent.y && extent.x >= extent.z { 0 }
-               else if extent.y >= extent.z { 1 }
-               else { 2 };
+    let axis = if extent.x >= extent.y && extent.x >= extent.z {
+        0
+    } else if extent.y >= extent.z {
+        1
+    } else {
+        2
+    };
 
     // Pokud je extent na vybrané ose téměř nulový, použij fallback
     if extent[axis] < 1e-6 {
@@ -190,7 +191,7 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
     #[derive(Clone)]
     struct Bucket {
         count: usize,
-        bb: BoundingBox
+        bb: BoundingBox,
     }
 
     let mut buckets_data = vec![
@@ -210,7 +211,8 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
     for (i, tri) in tris.iter().enumerate() {
         let c_axis = centroid_axis[i];
         let t = ((c_axis - mins[axis]) / extent[axis] * (buckets as f32))
-            .floor().clamp(0.0, (buckets - 1) as f32) as usize;
+            .floor()
+            .clamp(0.0, (buckets - 1) as f32) as usize;
         let b = &mut buckets_data[t];
         b.count += 1;
         b.bb = BoundingBox::encompass(&b.bb, &BoundingBox::from_triangle(tri));
@@ -282,12 +284,10 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
 
 // Upravená funkce build_bsp, která přiřazuje ID uzlům
 pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> BspNode {
-    const MIN_TRIANGLES: usize = 20;
-
     let my_id = *next_id;
     *next_id += 1;
 
-    if depth >= MAX_DEPTH || triangles.len() <= MIN_TRIANGLES {
+    if depth >= MAX_BSP_DEPTH || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
         return BspNode::new_leaf(triangles.to_vec(), my_id);
     }
 
@@ -299,9 +299,8 @@ pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> Bsp
     let splitting_plane = bucketed_sah_plane(triangles, 16);
 
     // Paralelní klasifikace trojúhelníků pomocí Rayon
-    let (front_triangles, back_triangles): (Vec<Triangle>, Vec<Triangle>) = triangles.par_iter()
-        .cloned()
-        .partition(|triangle| {
+    let (front_triangles, back_triangles): (Vec<Triangle>, Vec<Triangle>) =
+        triangles.par_iter().cloned().partition(|triangle| {
             let center = triangle_center(triangle);
             splitting_plane.classify(center) >= 0
         });
@@ -314,7 +313,7 @@ pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> Bsp
     // Rekurzivní stavba podstromů - use sequential processing to fix ID assignment
     let front_node = build_bsp(&front_triangles, depth + 1, next_id);
     let back_node = build_bsp(&back_triangles, depth + 1, next_id);
-    
+
     BspNode::new_node(splitting_plane, front_node, back_node, my_id)
 }
 
@@ -331,12 +330,21 @@ pub fn find_node(node: &BspNode, id: usize) -> Option<&BspNode> {
 
 /// Fills `path` with pointers from the root down *to* the node with `target_id`.
 /// Returns true if found.
-pub fn find_node_path<'a>(node: &'a BspNode, target_id: usize, path: &mut Vec<&'a BspNode>) -> bool {
+pub fn find_node_path<'a>(
+    node: &'a BspNode,
+    target_id: usize,
+    path: &mut Vec<&'a BspNode>,
+) -> bool {
     if node.id == target_id {
         path.push(node);
         return true;
     }
-    for child in node.front.as_deref().into_iter().chain(node.back.as_deref()) {
+    for child in node
+        .front
+        .as_deref()
+        .into_iter()
+        .chain(node.back.as_deref())
+    {
         if find_node_path(child, target_id, path) {
             path.push(node);
             return true;
@@ -345,7 +353,10 @@ pub fn find_node_path<'a>(node: &'a BspNode, target_id: usize, path: &mut Vec<&'
     false
 }
 
-pub fn find_deepest_node_containing_point<'a>(node: &'a BspNode, point: Vector3<f32>) -> Option<&'a BspNode> {
+pub fn find_deepest_node_containing_point<'a>(
+    node: &'a BspNode,
+    point: Vector3<f32>,
+) -> Option<&'a BspNode> {
     if !node.bounds.contains(point) {
         return None;
     }
@@ -365,13 +376,13 @@ pub fn find_deepest_node_containing_point<'a>(node: &'a BspNode, point: Vector3<
 // Funkce pro rekurzivní vykreslení stromu v UI a zpracování výběru uzlu
 pub fn render_bsp_tree(ui: &mut egui::Ui, node: &BspNode, selected: &mut Option<usize>) {
     // build the label
-    let is_leaf     = node.plane.is_none();
-    let local_tris  = node.triangles.len();
+    let is_leaf = node.plane.is_none();
+    let local_tris = node.triangles.len();
     // total tris in this subtree (using cached value)
     let subtree_tris = node.subtree_tris as usize;
     // number of children nodes
     let child_count = node.front.as_ref().map_or(0, |n| n.node_count - 1)
-                + node.back.as_ref().map_or(0, |n| n.node_count - 1);
+        + node.back.as_ref().map_or(0, |n| n.node_count - 1);
 
     let is_selected = selected == &Some(node.id);
     let label = if is_leaf {
@@ -384,21 +395,33 @@ pub fn render_bsp_tree(ui: &mut egui::Ui, node: &BspNode, selected: &mut Option<
     } else {
         // interior: show total subtree triangles
         if is_selected {
-            format!("🔸 Node {} ({} tris subtree, {} children)", node.id, subtree_tris, child_count)
+            format!(
+                "🔸 Node {} ({} tris subtree, {} children)",
+                node.id, subtree_tris, child_count
+            )
         } else {
-            format!("Node {} ({} tris subtree, {} children)", node.id, subtree_tris, child_count)
+            format!(
+                "Node {} ({} tris subtree, {} children)",
+                node.id, subtree_tris, child_count
+            )
         }
     };
 
     // collapsible header
     let header = egui::CollapsingHeader::new(label)
-        .id_salt(node.id)  // Aktualizace zastaralé metody id_source na id_salt
+        .id_salt(node.id) // Aktualizace zastaralé metody id_source na id_salt
         .default_open(node.id == selected.unwrap_or(0)); // auto-open the selected node
 
     // draw the header
     let response = header.show(ui, |ui| {
         // small "select" button inside the collapsible content
-        if ui.add(egui::SelectableLabel::new(selected == &Some(node.id), "▶ Select")).clicked() {
+        if ui
+            .add(egui::SelectableLabel::new(
+                selected == &Some(node.id),
+                "▶ Select",
+            ))
+            .clicked()
+        {
             *selected = Some(node.id);
         }
 
@@ -440,38 +463,50 @@ pub fn collect_triangles_in_subtree(node: &BspNode, triangles: &mut Vec<Triangle
 
 // Funkce pro vytvoření zvýrazněného meshe
 pub fn create_highlight_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
-    let positions: Vec<Vec3> = triangles.iter().flat_map(|tri| {
-        vec![
-            vec3(tri.a.x, tri.a.y, tri.a.z),
-            vec3(tri.b.x, tri.b.y, tri.b.z),
-            vec3(tri.c.x, tri.c.y, tri.c.z),
-        ]
-    }).collect();
-    
-    let indices: Vec<u32> = (0..triangles.len() as u32).flat_map(|i| {
-        let base = i * 3;
-        vec![base, base + 1, base + 2]
-    }).collect();
-    
+    let positions: Vec<Vec3> = triangles
+        .iter()
+        .flat_map(|tri| {
+            vec![
+                vec3(tri.a.x, tri.a.y, tri.a.z),
+                vec3(tri.b.x, tri.b.y, tri.b.z),
+                vec3(tri.c.x, tri.c.y, tri.c.z),
+            ]
+        })
+        .collect();
+
+    let indices: Vec<u32> = (0..triangles.len() as u32)
+        .flat_map(|i| {
+            let base = i * 3;
+            vec![base, base + 1, base + 2]
+        })
+        .collect();
+
     let cpu_mesh = CpuMesh {
         positions: Positions::F32(positions),
         indices: Indices::U32(indices),
         ..Default::default()
     };
-    
-    let material = ColorMaterial::new_transparent(context, &CpuMaterial {
-        albedo: Srgba::new(255, 50, 50, 150), // Červená s průhledností
-        ..Default::default()
-    });
-    
+
+    let material = ColorMaterial::new_transparent(
+        context,
+        &CpuMaterial {
+            albedo: HIGHLIGHT_COLOR, // configured highlight color
+            ..Default::default()
+        },
+    );
+
     Gm::new(Mesh::new(context, &cpu_mesh), material)
 }
 
 // Funkce pro vytvoření meshe dělící roviny
-pub fn create_plane_mesh(plane: &Plane, bounds: &BoundingBox, context: &Context) -> Gm<Mesh, ColorMaterial> {
+pub fn create_plane_mesh(
+    plane: &Plane,
+    bounds: &BoundingBox,
+    context: &Context,
+) -> Gm<Mesh, ColorMaterial> {
     // Vypočítáme střed obalového objemu
     let center = (bounds.min + bounds.max) * 0.5;
-    
+
     // Potřebujeme najít dva vektory kolmé na normálu roviny
     // Nejprve najdeme libovolný vektor kolmý na normálu
     let n = plane.n;
@@ -482,13 +517,13 @@ pub fn create_plane_mesh(plane: &Plane, bounds: &BoundingBox, context: &Context)
     } else {
         Vector3::new(-n.y, n.x, 0.0).normalize()
     };
-    
+
     // Druhý vektor kolmý na normálu a první vektor
     let v = n.cross(u).normalize();
-    
+
     // Velikost roviny - vycházíme z velikosti obalového objemu
     let extent = (bounds.max - bounds.min).magnitude() * 0.6;
-    
+
     // Vytvoříme čtyři rohy roviny
     let corners = [
         center + (u + v) * extent,
@@ -496,7 +531,7 @@ pub fn create_plane_mesh(plane: &Plane, bounds: &BoundingBox, context: &Context)
         center + (-u - v) * extent,
         center + (-u + v) * extent,
     ];
-    
+
     // Vytvoříme pozice a indexy pro mesh
     let positions = vec![
         vec3(corners[0].x, corners[0].y, corners[0].z),
@@ -504,21 +539,24 @@ pub fn create_plane_mesh(plane: &Plane, bounds: &BoundingBox, context: &Context)
         vec3(corners[2].x, corners[2].y, corners[2].z),
         vec3(corners[3].x, corners[3].y, corners[3].z),
     ];
-    
+
     // Dva trojúlníky pro čtyřúhelník
     let indices = vec![0, 1, 2, 2, 3, 0];
-    
+
     let cpu_mesh = CpuMesh {
         positions: Positions::F32(positions),
         indices: Indices::U32(indices),
         ..Default::default()
     };
-    
-    let material = ColorMaterial::new_transparent(context, &CpuMaterial {
-        albedo: Srgba::new(200, 200, 50, 128), // Žlutá s průhledností
-        ..Default::default()
-    });
-    
+
+    let material = ColorMaterial::new_transparent(
+        context,
+        &CpuMaterial {
+            albedo: PLANE_COLOR, // configured plane color
+            ..Default::default()
+        },
+    );
+
     Gm::new(Mesh::new(context, &cpu_mesh), material)
 }
 
@@ -543,16 +581,29 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
                     let c_idx = indices[i + 2] as usize;
 
                     // Kontrola, zda indexy jsou v rozsahu
-                    if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
-                        let a = Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z);
-                        let b = Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z);
-                        let c = Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z);
+                    if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len()
+                    {
+                        let a = Vector3::new(
+                            positions[a_idx].x,
+                            positions[a_idx].y,
+                            positions[a_idx].z,
+                        );
+                        let b = Vector3::new(
+                            positions[b_idx].x,
+                            positions[b_idx].y,
+                            positions[b_idx].z,
+                        );
+                        let c = Vector3::new(
+                            positions[c_idx].x,
+                            positions[c_idx].y,
+                            positions[c_idx].z,
+                        );
 
                         triangles.push(Triangle { a, b, c });
                     }
                 }
             }
-        },
+        }
         Indices::U16(indices) => {
             // Pro každou trojici indexů vytvoříme trojúhelník
             for i in (0..indices.len()).step_by(3) {
@@ -562,23 +613,38 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
                     let c_idx = indices[i + 2] as usize;
 
                     // Kontrola, zda indexy jsou v rozsahu
-                    if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
-                        let a = Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z);
-                        let b = Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z);
-                        let c = Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z);
+                    if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len()
+                    {
+                        let a = Vector3::new(
+                            positions[a_idx].x,
+                            positions[a_idx].y,
+                            positions[a_idx].z,
+                        );
+                        let b = Vector3::new(
+                            positions[b_idx].x,
+                            positions[b_idx].y,
+                            positions[b_idx].z,
+                        );
+                        let c = Vector3::new(
+                            positions[c_idx].x,
+                            positions[c_idx].y,
+                            positions[c_idx].z,
+                        );
 
                         triangles.push(Triangle { a, b, c });
                     }
                 }
             }
-        },
+        }
         Indices::None => {
             // Pokud nemáme indexy, předpokládáme, že pozice jsou přímo vrcholy trojúhelníků
             for i in (0..positions.len()).step_by(3) {
                 if i + 2 < positions.len() {
                     let a = Vector3::new(positions[i].x, positions[i].y, positions[i].z);
-                    let b = Vector3::new(positions[i + 1].x, positions[i + 1].y, positions[i + 1].z);
-                    let c = Vector3::new(positions[i + 2].x, positions[i + 2].y, positions[i + 2].z);
+                    let b =
+                        Vector3::new(positions[i + 1].x, positions[i + 1].y, positions[i + 1].z);
+                    let c =
+                        Vector3::new(positions[i + 2].x, positions[i + 2].y, positions[i + 2].z);
 
                     triangles.push(Triangle { a, b, c });
                 }
@@ -599,7 +665,7 @@ pub fn traverse_bsp_with_frustum(
     observer_position: Vector3<f32>,
     frustum: &Frustum,
     stats: &mut BspStats,
-    visible_triangles: &mut Vec<Triangle>
+    visible_triangles: &mut Vec<Triangle>,
 ) {
     stats.nodes_visited += 1;
 
@@ -636,29 +702,59 @@ pub fn traverse_bsp_with_frustum(
         if side >= 0 {
             // Pozorovatel je před rovinou, nejprve front, pak back
             if let Some(ref front) = node.front {
-                traverse_bsp_with_frustum(front, observer_position, frustum, stats, visible_triangles);
+                traverse_bsp_with_frustum(
+                    front,
+                    observer_position,
+                    frustum,
+                    stats,
+                    visible_triangles,
+                );
             }
             if let Some(ref back) = node.back {
-                traverse_bsp_with_frustum(back, observer_position, frustum, stats, visible_triangles);
+                traverse_bsp_with_frustum(
+                    back,
+                    observer_position,
+                    frustum,
+                    stats,
+                    visible_triangles,
+                );
             }
         } else {
             // Pozorovatel je za rovinou, nejprve back, pak front
             if let Some(ref back) = node.back {
-                traverse_bsp_with_frustum(back, observer_position, frustum, stats, visible_triangles);
+                traverse_bsp_with_frustum(
+                    back,
+                    observer_position,
+                    frustum,
+                    stats,
+                    visible_triangles,
+                );
             }
             if let Some(ref front) = node.front {
-                traverse_bsp_with_frustum(front, observer_position, frustum, stats, visible_triangles);
+                traverse_bsp_with_frustum(
+                    front,
+                    observer_position,
+                    frustum,
+                    stats,
+                    visible_triangles,
+                );
             }
         }
     }
 }
 
 // Funkce pro vytvoření materiálu a modelu z CPU meshe
-fn create_material_and_model(context: &Context, cpu_mesh: &CpuMesh) -> (ColorMaterial, Gm<Mesh, ColorMaterial>) {
-    let material = ColorMaterial::new_opaque(context, &CpuMaterial {
-        albedo: Srgba::new(100, 150, 255, 255), // Modrá barva aby byl model viditelný
-        ..Default::default()
-    });
+fn create_material_and_model(
+    context: &Context,
+    cpu_mesh: &CpuMesh,
+) -> (ColorMaterial, Gm<Mesh, ColorMaterial>) {
+    let material = ColorMaterial::new_opaque(
+        context,
+        &CpuMaterial {
+            albedo: Srgba::new(100, 150, 255, 255), // Modrá barva aby byl model viditelný
+            ..Default::default()
+        },
+    );
     let model = Gm::new(Mesh::new(context, cpu_mesh), material.clone());
 
     (material, model)
@@ -666,22 +762,35 @@ fn create_material_and_model(context: &Context, cpu_mesh: &CpuMesh) -> (ColorMat
 
 // Funkce pro vytvoření glow materiálu
 fn create_glow_material(context: &Context, color: Srgba, opacity: u8) -> ColorMaterial {
-    ColorMaterial::new_transparent(context, &CpuMaterial {
-        albedo: Srgba::new(color.r, color.g, color.b, opacity),
-        ..Default::default()
-    })
+    ColorMaterial::new_transparent(
+        context,
+        &CpuMaterial {
+            albedo: Srgba::new(color.r, color.g, color.b, opacity),
+            ..Default::default()
+        },
+    )
 }
 
 // Funkce pro vytvoření směrového materiálu
 fn create_direction_material(context: &Context, color: Srgba, opacity: u8) -> ColorMaterial {
-    ColorMaterial::new_transparent(context, &CpuMaterial {
-        albedo: Srgba::new(color.r, color.g, color.b, opacity),
-        ..Default::default()
-    })
+    ColorMaterial::new_transparent(
+        context,
+        &CpuMaterial {
+            albedo: Srgba::new(color.r, color.g, color.b, opacity),
+            ..Default::default()
+        },
+    )
 }
 
 // Funkce pro vytvoření směrového paprsku
-fn create_direction_ray(context: &Context, position: Vector3<f32>, direction: Vector3<f32>, color: Srgba, opacity: u8, length: f32) -> Gm<Mesh, ColorMaterial> {
+fn create_direction_ray(
+    context: &Context,
+    position: Vector3<f32>,
+    direction: Vector3<f32>,
+    color: Srgba,
+    opacity: u8,
+    length: f32,
+) -> Gm<Mesh, ColorMaterial> {
     let direction_material = create_direction_material(context, color, opacity);
     let direction_mesh = CpuMesh::cone(16);
     let mut direction_ray = Gm::new(Mesh::new(context, &direction_mesh), direction_material);
@@ -710,14 +819,14 @@ fn create_direction_ray(context: &Context, position: Vector3<f32>, direction: Ve
         // Normální případ - rotace kolem vypočtené osy
         Mat4::from_axis_angle(
             vec3(rotation_axis.x, rotation_axis.y, rotation_axis.z),
-            Rad(angle)
+            Rad(angle),
         )
     };
-    
+
     // Měřítko - válec - válec je standardně výšky 2.0, chceme jej natáhnout na délku `length`
     // a zúžit na šířku `scale`
     let scaling = Mat4::from_nonuniform_scale(scale, length / 2.0, scale);
-    
+
     // Aplikujeme transformace v pořadí: měřítko, rotace, posun
     direction_ray.set_transformation(translation * rotation * scaling);
 
@@ -739,9 +848,12 @@ impl BoundingBox {
     }
 
     pub fn contains(&self, point: Vector3<f32>) -> bool {
-        point.x >= self.min.x && point.x <= self.max.x &&
-        point.y >= self.min.y && point.y <= self.max.y &&
-        point.z >= self.min.z && point.z <= self.max.z
+        point.x >= self.min.x
+            && point.x <= self.max.x
+            && point.y >= self.min.y
+            && point.y <= self.max.y
+            && point.z >= self.min.z
+            && point.z <= self.max.z
     }
 
     fn from_triangle(tri: &Triangle) -> Self {
@@ -796,9 +908,21 @@ impl BoundingBox {
     fn intersects_plane(&self, plane: &Plane) -> bool {
         // compute the "positive vertex" for this plane's normal
         let p = Vector3::new(
-            if plane.n.x >= 0.0 { self.max.x } else { self.min.x },
-            if plane.n.y >= 0.0 { self.max.y } else { self.min.y },
-            if plane.n.z >= 0.0 { self.max.z } else { self.min.z },
+            if plane.n.x >= 0.0 {
+                self.max.x
+            } else {
+                self.min.x
+            },
+            if plane.n.y >= 0.0 {
+                self.max.y
+            } else {
+                self.min.y
+            },
+            if plane.n.z >= 0.0 {
+                self.max.z
+            } else {
+                self.min.z
+            },
         );
         // if this farthest point is in front, the box may intersect or be in front
         plane.side(p) >= 0.0
@@ -826,71 +950,65 @@ impl Frustum {
 
         // Převedeme na pole - Matrix4 nemá as_slice(), musíme použít jiný přístup
         let mat = [
-            vp_matrix.x.x, vp_matrix.x.y, vp_matrix.x.z, vp_matrix.x.w,
-            vp_matrix.y.x, vp_matrix.y.y, vp_matrix.y.z, vp_matrix.y.w,
-            vp_matrix.z.x, vp_matrix.z.y, vp_matrix.z.z, vp_matrix.z.w,
-            vp_matrix.w.x, vp_matrix.w.y, vp_matrix.w.z, vp_matrix.w.w,
+            vp_matrix.x.x,
+            vp_matrix.x.y,
+            vp_matrix.x.z,
+            vp_matrix.x.w,
+            vp_matrix.y.x,
+            vp_matrix.y.y,
+            vp_matrix.y.z,
+            vp_matrix.y.w,
+            vp_matrix.z.x,
+            vp_matrix.z.y,
+            vp_matrix.z.z,
+            vp_matrix.z.w,
+            vp_matrix.w.x,
+            vp_matrix.w.y,
+            vp_matrix.w.z,
+            vp_matrix.w.w,
         ];
 
         // Extrahujeme 6 rovin frustumu
         // Levá rovina
         let left = Plane {
-            n: Vector3::new(
-                mat[3] + mat[0],
-                mat[7] + mat[4],
-                mat[11] + mat[8],
-            ).normalize(),
-            d: (mat[15] + mat[12]) / (mat[3] + mat[0]).hypot((mat[7] + mat[4]).hypot(mat[11] + mat[8])),
+            n: Vector3::new(mat[3] + mat[0], mat[7] + mat[4], mat[11] + mat[8]).normalize(),
+            d: (mat[15] + mat[12])
+                / (mat[3] + mat[0]).hypot((mat[7] + mat[4]).hypot(mat[11] + mat[8])),
         };
 
         // Pravá rovina
         let right = Plane {
-            n: Vector3::new(
-                mat[3] - mat[0],
-                mat[7] - mat[4],
-                mat[11] - mat[8],
-            ).normalize(),
-            d: (mat[15] - mat[12]) / (mat[3] - mat[0]).hypot((mat[7] - mat[4]).hypot(mat[11] - mat[8])),
+            n: Vector3::new(mat[3] - mat[0], mat[7] - mat[4], mat[11] - mat[8]).normalize(),
+            d: (mat[15] - mat[12])
+                / (mat[3] - mat[0]).hypot((mat[7] - mat[4]).hypot(mat[11] - mat[8])),
         };
 
         // Spodní rovina
         let bottom = Plane {
-            n: Vector3::new(
-                mat[3] + mat[1],
-                mat[7] + mat[5],
-                mat[11] + mat[9],
-            ).normalize(),
-            d: (mat[15] + mat[13]) / (mat[3] + mat[1]).hypot((mat[7] + mat[5]).hypot(mat[11] + mat[9])),
+            n: Vector3::new(mat[3] + mat[1], mat[7] + mat[5], mat[11] + mat[9]).normalize(),
+            d: (mat[15] + mat[13])
+                / (mat[3] + mat[1]).hypot((mat[7] + mat[5]).hypot(mat[11] + mat[9])),
         };
 
         // Horní rovina
         let top = Plane {
-            n: Vector3::new(
-                mat[3] - mat[1],
-                mat[7] - mat[5],
-                mat[11] - mat[9],
-            ).normalize(),
-            d: (mat[15] - mat[13]) / (mat[3] - mat[1]).hypot((mat[7] - mat[5]).hypot(mat[11] - mat[9])),
+            n: Vector3::new(mat[3] - mat[1], mat[7] - mat[5], mat[11] - mat[9]).normalize(),
+            d: (mat[15] - mat[13])
+                / (mat[3] - mat[1]).hypot((mat[7] - mat[5]).hypot(mat[11] - mat[9])),
         };
 
         // Blízká rovina
         let near = Plane {
-            n: Vector3::new(
-                mat[3] + mat[2],
-                mat[7] + mat[6],
-                mat[11] + mat[10],
-            ).normalize(),
-            d: (mat[15] + mat[14]) / (mat[3] + mat[2]).hypot((mat[7] + mat[6]).hypot(mat[11] + mat[10])),
+            n: Vector3::new(mat[3] + mat[2], mat[7] + mat[6], mat[11] + mat[10]).normalize(),
+            d: (mat[15] + mat[14])
+                / (mat[3] + mat[2]).hypot((mat[7] + mat[6]).hypot(mat[11] + mat[10])),
         };
 
         // Vzdálená rovina
         let far = Plane {
-            n: Vector3::new(
-                mat[3] - mat[2],
-                mat[7] - mat[6],
-                mat[11] - mat[10],
-            ).normalize(),
-            d: (mat[15] - mat[14]) / (mat[3] - mat[2]).hypot((mat[7] - mat[6]).hypot(mat[11] - mat[10])),
+            n: Vector3::new(mat[3] - mat[2], mat[7] - mat[6], mat[11] - mat[10]).normalize(),
+            d: (mat[15] - mat[14])
+                / (mat[3] - mat[2]).hypot((mat[7] - mat[6]).hypot(mat[11] - mat[10])),
         };
 
         Frustum {
@@ -900,12 +1018,42 @@ impl Frustum {
 
     pub fn as_vec4_array(&self) -> [[f32; 4]; 6] {
         [
-            [self.planes[0].n.x, self.planes[0].n.y, self.planes[0].n.z, self.planes[0].d],
-            [self.planes[1].n.x, self.planes[1].n.y, self.planes[1].n.z, self.planes[1].d],
-            [self.planes[2].n.x, self.planes[2].n.y, self.planes[2].n.z, self.planes[2].d],
-            [self.planes[3].n.x, self.planes[3].n.y, self.planes[3].n.z, self.planes[3].d],
-            [self.planes[4].n.x, self.planes[4].n.y, self.planes[4].n.z, self.planes[4].d],
-            [self.planes[5].n.x, self.planes[5].n.y, self.planes[5].n.z, self.planes[5].d],
+            [
+                self.planes[0].n.x,
+                self.planes[0].n.y,
+                self.planes[0].n.z,
+                self.planes[0].d,
+            ],
+            [
+                self.planes[1].n.x,
+                self.planes[1].n.y,
+                self.planes[1].n.z,
+                self.planes[1].d,
+            ],
+            [
+                self.planes[2].n.x,
+                self.planes[2].n.y,
+                self.planes[2].n.z,
+                self.planes[2].d,
+            ],
+            [
+                self.planes[3].n.x,
+                self.planes[3].n.y,
+                self.planes[3].n.z,
+                self.planes[3].d,
+            ],
+            [
+                self.planes[4].n.x,
+                self.planes[4].n.y,
+                self.planes[4].n.z,
+                self.planes[4].d,
+            ],
+            [
+                self.planes[5].n.x,
+                self.planes[5].n.y,
+                self.planes[5].n.z,
+                self.planes[5].d,
+            ],
         ]
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,20 @@
+//! Central place for user‑tunable parameters.
+//! Values here can be quickly adjusted without digging
+//! through the rest of the code base.
+
+use three_d::Srgba;
+
+/// Background color of the main render target (RGB 0.0‑1.0).
+pub const BG_COLOR: (f32, f32, f32) = (0.1, 0.1, 0.1);
+
+/// Color used to highlight the currently selected geometry.
+pub const HIGHLIGHT_COLOR: Srgba = Srgba::new(255, 50, 50, 150);
+
+/// Color of the optional splitting plane preview.
+pub const PLANE_COLOR: Srgba = Srgba::new(200, 200, 50, 128);
+
+/// Maximum allowed depth when building the BSP tree.
+pub const MAX_BSP_DEPTH: u32 = 16;
+
+/// Minimum number of triangles inside a leaf before we stop splitting.
+pub const MIN_TRIANGLES_PER_LEAF: usize = 20;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,24 +23,30 @@
 
 use anyhow::Result;
 use cgmath::{Deg, InnerSpace, Vector3};
+use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
-use three_d::*;
-use rayon::prelude::*; // Add Rayon prelude for parallelization
+use three_d::*; // Add Rayon prelude for parallelization
 
 mod gpu_job;
 mod shaders;
+use crate::bsp::{
+    build_bsp, collect_triangles_in_subtree, cpu_mesh_to_triangles, create_highlight_mesh,
+    create_plane_mesh, find_deepest_node_containing_point, find_node, traverse_bsp_with_frustum,
+    triangle_center, BspNode, BspStats, Frustum, Triangle,
+};
+use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
+use crate::config::BG_COLOR;
 use crate::gpu_job::GpuJob;
 use crate::input::{InputManager, KeyCode};
-use crate::camera::{FreeCamera, CamMode, CameraState, SwitchDelay};
-use crate::bsp::{BspNode, BspStats, Triangle, Frustum, build_bsp, find_node, find_deepest_node_containing_point, collect_triangles_in_subtree, create_plane_mesh, create_highlight_mesh, cpu_mesh_to_triangles, traverse_bsp_with_frustum, triangle_center};
 
-mod input;
-mod camera;
 mod bsp;
+mod camera;
+mod config; // global constants
 mod gui;
-// Message types for the channel
+mod input;
+           // Message types for the channel
 #[derive(Debug)]
 enum Message {
     InitialTree(BspNode),
@@ -49,12 +55,9 @@ enum Message {
         triangles: Vec<Triangle>,
         file_name: String,
         load_status: String,
-        bsp_tree: BspNode
+        bsp_tree: BspNode,
     },
 }
-
-
-
 
 // helper: načte CpuMesh z .glb/.gltf pomocí gltf crate
 fn load_cpu_mesh(path: &Path) -> (CpuMesh, String) {
@@ -62,7 +65,10 @@ fn load_cpu_mesh(path: &Path) -> (CpuMesh, String) {
 
     if !path.exists() {
         println!("Soubor neexistuje: {}", path.display());
-        return (CpuMesh::sphere(32), format!("Soubor neexistuje: {}", path.display()));
+        return (
+            CpuMesh::sphere(32),
+            format!("Soubor neexistuje: {}", path.display()),
+        );
     }
 
     match std::fs::metadata(path) {
@@ -71,10 +77,14 @@ fn load_cpu_mesh(path: &Path) -> (CpuMesh, String) {
             if metadata.len() == 0 {
                 return (CpuMesh::sphere(32), "Soubor je prázdný".to_string());
             }
-            if metadata.len() > 100_000_000 { // 100MB limit
-                return (CpuMesh::sphere(32), "Soubor je příliš velký (>100MB)".to_string());
+            if metadata.len() > 100_000_000 {
+                // 100MB limit
+                return (
+                    CpuMesh::sphere(32),
+                    "Soubor je příliš velký (>100MB)".to_string(),
+                );
             }
-        },
+        }
         Err(e) => {
             println!("Nelze přečíst metadata souboru: {}", e);
             return (CpuMesh::sphere(32), format!("Chyba metadata: {}", e));
@@ -86,22 +96,25 @@ fn load_cpu_mesh(path: &Path) -> (CpuMesh, String) {
         Ok(mesh) => {
             println!("✓ GLTF úspěšně načten pomocí gltf crate");
             return (mesh, "GLTF soubor úspěšně načten".to_string());
-        },
+        }
         Err(e) => {
             println!("Chyba při načítání pomocí gltf crate: {}", e);
-            return (CpuMesh::sphere(32), format!("Nepodařilo se načíst GLTF: {}", e));
+            return (
+                CpuMesh::sphere(32),
+                format!("Nepodařilo se načíst GLTF: {}", e),
+            );
         }
     }
 }
 
 fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
     println!("Načítám GLTF pomocí gltf crate...");
-    
+
     let (document, buffers, _images) = gltf::import(path)?;
-    
+
     println!("GLTF dokument načten:");
     println!("- Scény: {}", document.scenes().count());
-    println!("- Uzly: {}", document.nodes().count());  
+    println!("- Uzly: {}", document.nodes().count());
     println!("- Meshe: {}", document.meshes().count());
     println!("- Materiály: {}", document.materials().count());
 
@@ -112,9 +125,16 @@ fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
     // Projdi všechny meshe ve scéně
     for scene in document.scenes() {
         println!("Zpracovávám scénu: {:?}", scene.name());
-        
+
         for node in scene.nodes() {
-            process_node(&node, &buffers, &mut all_positions, &mut all_indices, &mut vertex_offset, cgmath::Matrix4::identity())?;
+            process_node(
+                &node,
+                &buffers,
+                &mut all_positions,
+                &mut all_indices,
+                &mut vertex_offset,
+                cgmath::Matrix4::identity(),
+            )?;
         }
     }
 
@@ -122,14 +142,18 @@ fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
         anyhow::bail!("Žádné pozice nenalezeny v GLTF souboru");
     }
 
-    println!("Celkem načteno {} vrcholů a {} indexů", all_positions.len(), all_indices.len());
+    println!(
+        "Celkem načteno {} vrcholů a {} indexů",
+        all_positions.len(),
+        all_indices.len()
+    );
 
     Ok(CpuMesh {
         positions: Positions::F32(all_positions),
-        indices: if all_indices.is_empty() { 
-            Indices::None 
-        } else { 
-            Indices::U32(all_indices) 
+        indices: if all_indices.is_empty() {
+            Indices::None
+        } else {
+            Indices::U32(all_indices)
         },
         ..Default::default()
     })
@@ -141,7 +165,7 @@ fn process_node(
     all_positions: &mut Vec<Vec3>,
     all_indices: &mut Vec<u32>,
     vertex_offset: &mut u32,
-    parent_transform: cgmath::Matrix4<f32>
+    parent_transform: cgmath::Matrix4<f32>,
 ) -> Result<()> {
     // Získej transformaci uzlu
     let transform_matrix = cgmath::Matrix4::from(node.transform().matrix());
@@ -151,16 +175,34 @@ fn process_node(
 
     // Zpracuj mesh pokud existuje
     if let Some(mesh) = node.mesh() {
-        println!("Zpracovávám mesh: {:?} s {} primitivy", mesh.name(), mesh.primitives().count());
-        
+        println!(
+            "Zpracovávám mesh: {:?} s {} primitivy",
+            mesh.name(),
+            mesh.primitives().count()
+        );
+
         for primitive in mesh.primitives() {
-            process_primitive(&primitive, buffers, all_positions, all_indices, vertex_offset, current_transform)?;
+            process_primitive(
+                &primitive,
+                buffers,
+                all_positions,
+                all_indices,
+                vertex_offset,
+                current_transform,
+            )?;
         }
     }
 
     // Rekurzivně zpracuj potomky
     for child in node.children() {
-        process_node(&child, buffers, all_positions, all_indices, vertex_offset, current_transform)?;
+        process_node(
+            &child,
+            buffers,
+            all_positions,
+            all_indices,
+            vertex_offset,
+            current_transform,
+        )?;
     }
 
     Ok(())
@@ -172,7 +214,7 @@ fn process_primitive(
     all_positions: &mut Vec<Vec3>,
     all_indices: &mut Vec<u32>,
     vertex_offset: &mut u32,
-    transform: cgmath::Matrix4<f32>
+    transform: cgmath::Matrix4<f32>,
 ) -> Result<()> {
     println!("Zpracovávám primitiv s modem: {:?}", primitive.mode());
 
@@ -184,17 +226,17 @@ fn process_primitive(
 
     // Získej pozice vrcholů
     let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
-    
+
     if let Some(positions) = reader.read_positions() {
         let start_vertex_count = all_positions.len();
-        
+
         // Přidej pozice s transformací
         for position in positions {
             let pos = cgmath::Vector4::new(position[0], position[1], position[2], 1.0);
             let transformed = transform * pos;
             all_positions.push(Vec3::new(transformed.x, transformed.y, transformed.z));
         }
-        
+
         let vertex_count = all_positions.len() - start_vertex_count;
         println!("Přidáno {} vrcholů", vertex_count);
 
@@ -205,12 +247,12 @@ fn process_primitive(
                     for idx in iter {
                         all_indices.push(idx as u32 + *vertex_offset);
                     }
-                },
+                }
                 gltf::mesh::util::ReadIndices::U16(iter) => {
                     for idx in iter {
                         all_indices.push(idx as u32 + *vertex_offset);
                     }
-                },
+                }
                 gltf::mesh::util::ReadIndices::U32(iter) => {
                     for idx in iter {
                         all_indices.push(idx + *vertex_offset);
@@ -242,21 +284,27 @@ fn process_primitive(
 fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
     // Paralelní zpracování pozic a indexů
     let triangles_count = triangles.len();
-    
+
     // Paralelně vytvoříme pozice vrcholů
-    let positions: Vec<Vec3> = triangles.par_iter().flat_map(|tri| {
-        vec![
-            vec3(tri.a.x, tri.a.y, tri.a.z),
-            vec3(tri.b.x, tri.b.y, tri.b.z),
-            vec3(tri.c.x, tri.c.y, tri.c.z),
-        ]
-    }).collect();
-    
+    let positions: Vec<Vec3> = triangles
+        .par_iter()
+        .flat_map(|tri| {
+            vec![
+                vec3(tri.a.x, tri.a.y, tri.a.z),
+                vec3(tri.b.x, tri.b.y, tri.b.z),
+                vec3(tri.c.x, tri.c.y, tri.c.z),
+            ]
+        })
+        .collect();
+
     // Paralelně vygenerujeme indexy
-    let indices: Vec<u32> = (0..triangles_count as u32).into_par_iter().flat_map(|i| {
-        let base_idx = i * 3;
-        vec![base_idx, base_idx + 1, base_idx + 2]
-    }).collect();
+    let indices: Vec<u32> = (0..triangles_count as u32)
+        .into_par_iter()
+        .flat_map(|i| {
+            let base_idx = i * 3;
+            vec![base_idx, base_idx + 1, base_idx + 2]
+        })
+        .collect();
 
     // Vytvoření nového meshe
     let visible_mesh = CpuMesh {
@@ -264,13 +312,16 @@ fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, Co
         indices: Indices::U32(indices),
         ..Default::default()
     };
-    
+
     // Vytvoření materiálu a modelu
-    let material = ColorMaterial::new_opaque(context, &CpuMaterial {
-        albedo: Srgba::new(100, 150, 255, 255),
-        ..Default::default()
-    });
-    
+    let material = ColorMaterial::new_opaque(
+        context,
+        &CpuMaterial {
+            albedo: Srgba::new(100, 150, 255, 255),
+            ..Default::default()
+        },
+    );
+
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
 
@@ -284,7 +335,9 @@ fn gpu_cull_triangles(job: &GpuJob, tris: &[Triangle], frustum: &Frustum) -> Vec
             bytes.extend_from_slice(&1f32.to_ne_bytes());
         }
     }
-    unsafe { job.update_ssbo_data(&bytes); }
+    unsafe {
+        job.update_ssbo_data(&bytes);
+    }
 
     let planes = frustum.as_vec4_array();
     let mut flat = [0f32; 24];
@@ -320,9 +373,9 @@ fn main() -> Result<()> {
     println!("🚀 Spouštím BSP Viewer...");
 
     // okno + GL
-    let window = Window::new(WindowSettings { 
-        title: "BSP Viewer (three‑d 0.18)".into(), 
-        ..Default::default() 
+    let window = Window::new(WindowSettings {
+        title: "BSP Viewer (three‑d 0.18)".into(),
+        ..Default::default()
     })?;
     println!("✓ Okno vytvořeno");
 
@@ -337,7 +390,11 @@ fn main() -> Result<()> {
     println!("✓ Model načten");
 
     let mut loaded_file_name = if initial_path.exists() {
-        initial_path.file_name().unwrap().to_string_lossy().into_owned()
+        initial_path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
     } else {
         "embedded sphere".to_string()
     };
@@ -396,39 +453,53 @@ fn main() -> Result<()> {
 
     // stav pro vykreslovaný mesh
     let _glb_path: Option<PathBuf> = None;
-    let material = ColorMaterial::new_opaque(&context, &CpuMaterial {
-        albedo: Srgba::new(100, 150, 255, 255), // Modrá barva aby byl model viditelný
-        ..Default::default()
-    });
+    let material = ColorMaterial::new_opaque(
+        &context,
+        &CpuMaterial {
+            albedo: Srgba::new(100, 150, 255, 255), // Modrá barva aby byl model viditelný
+            ..Default::default()
+        },
+    );
     let _model = Gm::new(Mesh::new(&context, &cpu_mesh), material.clone());
-    
+
     // Glow efekty pro pozice kamer
     let glow_mesh = CpuMesh::sphere(16);
-    
+
     // Materiály pro glow efekty
-    let spectator_glow_material = ColorMaterial::new_opaque(&context, &CpuMaterial {
-        albedo: Srgba::new(0, 255, 100, 200), // Zelená pro spectator
-        ..Default::default()
-    });
-    
-    let third_person_glow_material = ColorMaterial::new_opaque(&context, &CpuMaterial {
-        albedo: Srgba::new(255, 100, 0, 200), // Oranžová pro third person
-        ..Default::default()
-    });
-    
+    let spectator_glow_material = ColorMaterial::new_opaque(
+        &context,
+        &CpuMaterial {
+            albedo: Srgba::new(0, 255, 100, 200), // Zelená pro spectator
+            ..Default::default()
+        },
+    );
+
+    let third_person_glow_material = ColorMaterial::new_opaque(
+        &context,
+        &CpuMaterial {
+            albedo: Srgba::new(255, 100, 0, 200), // Oranžová pro third person
+            ..Default::default()
+        },
+    );
+
     // Materiál pro směrový paprsek kamery
-    let direction_material = ColorMaterial::new_opaque(&context, &CpuMaterial {
-        albedo: Srgba::new(255, 255, 0, 200), // Žlutá barva pro směrový paprsek
-        ..Default::default()
-    });
+    let direction_material = ColorMaterial::new_opaque(
+        &context,
+        &CpuMaterial {
+            albedo: Srgba::new(255, 255, 0, 200), // Žlutá barva pro směrový paprsek
+            ..Default::default()
+        },
+    );
 
     let mut spectator_glow = Gm::new(Mesh::new(&context, &glow_mesh), spectator_glow_material);
-    let mut third_person_glow = Gm::new(Mesh::new(&context, &glow_mesh), third_person_glow_material);
-    
+    let mut third_person_glow =
+        Gm::new(Mesh::new(&context, &glow_mesh), third_person_glow_material);
+
     // Vytvoření kuželu (cone) pro směrový indikátor kamery místo cylindru
     let direction_mesh = CpuMesh::cone(16);
-    let mut camera_direction_ray = Gm::new(Mesh::new(&context, &direction_mesh), direction_material);
-    
+    let mut camera_direction_ray =
+        Gm::new(Mesh::new(&context, &direction_mesh), direction_material);
+
     let ambient_light = AmbientLight::new(&context, 1.0, Srgba::WHITE); // Zvýšit intenzitu světla
 
     // Nastavení výchozích pozic pro kamery (spawnpoint)
@@ -440,18 +511,26 @@ fn main() -> Result<()> {
     let mut spectator_state = CameraState::from_camera(&cam);
     let mut third_person_state = CameraState::new(default_third_person_pos); // Jiná pozice pro lepší vizualizaci
     let mut mode = CamMode::Spectator;
-    
+
     // Proměnná pro sledování, zda zobrazit směr pohledu kamery
     let mut show_camera_direction = false;
 
     // Nastavení pozic glow efektů podle stavů kamer
-    spectator_glow.set_transformation(Mat4::from_translation(vec3(
-        spectator_state.pos.x, spectator_state.pos.y, spectator_state.pos.z
-    )) * Mat4::from_scale(0.2)); // Malé koule
-    
-    third_person_glow.set_transformation(Mat4::from_translation(vec3(
-        third_person_state.pos.x, third_person_state.pos.y, third_person_state.pos.z
-    )) * Mat4::from_scale(0.2));
+    spectator_glow.set_transformation(
+        Mat4::from_translation(vec3(
+            spectator_state.pos.x,
+            spectator_state.pos.y,
+            spectator_state.pos.z,
+        )) * Mat4::from_scale(0.2),
+    ); // Malé koule
+
+    third_person_glow.set_transformation(
+        Mat4::from_translation(vec3(
+            third_person_state.pos.x,
+            third_person_state.pos.y,
+            third_person_state.pos.z,
+        )) * Mat4::from_scale(0.2),
+    );
 
     // Inicializace InputManageru pro plynulé ovládání s více klávesami
     let mut input_manager = InputManager::new();
@@ -477,7 +556,13 @@ fn main() -> Result<()> {
                     bsp_root = Some(tree);
                     println!("✅ BSP strom úspěšně načten do GUI!");
                 }
-                Message::NewFile { cpu_mesh: new_cpu_mesh, triangles: new_triangles, file_name, load_status: _, bsp_tree } => {
+                Message::NewFile {
+                    cpu_mesh: new_cpu_mesh,
+                    triangles: new_triangles,
+                    file_name,
+                    load_status: _,
+                    bsp_tree,
+                } => {
                     current_cpu_mesh = new_cpu_mesh;
                     current_triangles = new_triangles;
                     loaded_file_name = file_name;
@@ -505,10 +590,17 @@ fn main() -> Result<()> {
         // Vytvoření frustumu kamery pro view-culling
         let camera_obj = cam.cam(frame_input.viewport);
 
-        // Zpracuj kliknutí myší pro výběr uzlu
+        // Handle mouse clicks: cast a ray into the scene and select the
+        // deepest BSP node containing the hit point. The selected ID is
+        // reflected in the left control panel.
         let mut click_position = None;
         for event in events {
-            if let Event::MousePress { button: MouseButton::Left, position, .. } = event {
+            if let Event::MousePress {
+                button: MouseButton::Left,
+                position,
+                ..
+            } = event
+            {
                 click_position = Some(*position);
             }
         }
@@ -523,22 +615,23 @@ fn main() -> Result<()> {
                 }
             }
         }
-        
+
         // Použij správnou pozici pozorovatele pro traverzování BSP stromu
         let observer_position = match mode {
-            CamMode::Spectator => cam.pos,  // V režimu Spectator používáme pozici kamery
-            CamMode::ThirdPerson => spectator_state.pos,  // V režimu ThirdPerson používáme pozici Spectator kamery
+            CamMode::Spectator => cam.pos, // V režimu Spectator používáme pozici kamery
+            CamMode::ThirdPerson => spectator_state.pos, // V režimu ThirdPerson používáme pozici Spectator kamery
         };
-        
+
         // V třetí osobě vytvoříme frustum z pozice pozorovatele
         let frustum = if mode == CamMode::ThirdPerson {
             // Vytvoříme kameru z pozice spectator
             let spectator_dir = Vector3::new(
                 spectator_state.yaw.cos() * spectator_state.pitch.cos(),
                 spectator_state.pitch.sin(),
-                spectator_state.yaw.sin() * spectator_state.pitch.cos()
-            ).normalize();
-            
+                spectator_state.yaw.sin() * spectator_state.pitch.cos(),
+            )
+            .normalize();
+
             let spectator_camera = Camera::new_perspective(
                 frame_input.viewport,
                 spectator_state.pos,
@@ -546,7 +639,7 @@ fn main() -> Result<()> {
                 Vector3::unit_y(),
                 Deg(60.0),
                 0.1,
-                1000.0
+                1000.0,
             );
             Frustum::from_camera(&spectator_camera)
         } else {
@@ -576,7 +669,13 @@ fn main() -> Result<()> {
         } else {
             let mut tris = Vec::new();
             if let Some(ref root) = bsp_root {
-                traverse_bsp_with_frustum(root, observer_position, &frustum, &mut current_stats, &mut tris);
+                traverse_bsp_with_frustum(
+                    root,
+                    observer_position,
+                    &frustum,
+                    &mut current_stats,
+                    &mut tris,
+                );
             }
             tris
         };
@@ -594,7 +693,11 @@ fn main() -> Result<()> {
         // Pomocná funkce pro kvantizaci středu trojúhelníku
         fn quantized_center(tri: &Triangle) -> (i32, i32, i32) {
             let c = triangle_center(tri);
-            ((c.x * 1000.0) as i32, (c.y * 1000.0) as i32, (c.z * 1000.0) as i32)
+            (
+                (c.x * 1000.0) as i32,
+                (c.y * 1000.0) as i32,
+                (c.z * 1000.0) as i32,
+            )
         }
 
         use std::collections::HashSet;
@@ -628,29 +731,35 @@ fn main() -> Result<()> {
         };
 
         // --- GUI ---
-        gui.update(&mut frame_input.events.clone(), frame_input.accumulated_time, frame_input.viewport, frame_input.device_pixel_ratio, |ctx| {
-            crate::gui::draw_left_panel(
-                ctx,
-                mode,
-                &mut loaded_file_name,
-                &mut file_loading,
-                &tx_gui,
-                &rx,
-                &mut current_cpu_mesh,
-                &mut current_triangles,
-                &mut bsp_root,
-                &mut selected_node,
-                &mut show_splitting_plane,
-                &mut disable_culling,
-                &mut use_gpu_culling,
-                &mut hide_selected_area,
-                &mut show_camera_direction,
-                &mut spectator_state,
-                &mut third_person_state,
-                &mut cam,
-                &current_stats,
-            );
-        });
+        gui.update(
+            &mut frame_input.events.clone(),
+            frame_input.accumulated_time,
+            frame_input.viewport,
+            frame_input.device_pixel_ratio,
+            |ctx| {
+                crate::gui::draw_left_panel(
+                    ctx,
+                    mode,
+                    &mut loaded_file_name,
+                    &mut file_loading,
+                    &tx_gui,
+                    &rx,
+                    &mut current_cpu_mesh,
+                    &mut current_triangles,
+                    &mut bsp_root,
+                    &mut selected_node,
+                    &mut show_splitting_plane,
+                    &mut disable_culling,
+                    &mut use_gpu_culling,
+                    &mut hide_selected_area,
+                    &mut show_camera_direction,
+                    &mut spectator_state,
+                    &mut third_person_state,
+                    &mut cam,
+                    &current_stats,
+                );
+            },
+        );
 
         // --- ovládání ---
         // --- ovládání přepnutí režimu pomocí kláves F a G ---
@@ -669,7 +778,7 @@ fn main() -> Result<()> {
                         spectator_state.apply_to_camera(&mut cam);
 
                         println!("Přepnuto na režim: Spectator");
-                    },
+                    }
                     CamMode::ThirdPerson => {
                         // Ulož aktuální pozici do Spectator stavu
                         spectator_state = CameraState::from_camera(&cam);
@@ -686,13 +795,21 @@ fn main() -> Result<()> {
                 switch_delay.record_switch(current_time);
 
                 // Aktualizuj pozice glow značek
-                spectator_glow.set_transformation(Mat4::from_translation(vec3(
-                    spectator_state.pos.x, spectator_state.pos.y, spectator_state.pos.z
-                )) * Mat4::from_scale(0.2));
-                
-                third_person_glow.set_transformation(Mat4::from_translation(vec3(
-                    third_person_state.pos.x, third_person_state.pos.y, third_person_state.pos.z
-                )) * Mat4::from_scale(0.2));
+                spectator_glow.set_transformation(
+                    Mat4::from_translation(vec3(
+                        spectator_state.pos.x,
+                        spectator_state.pos.y,
+                        spectator_state.pos.z,
+                    )) * Mat4::from_scale(0.2),
+                );
+
+                third_person_glow.set_transformation(
+                    Mat4::from_translation(vec3(
+                        third_person_state.pos.x,
+                        third_person_state.pos.y,
+                        third_person_state.pos.z,
+                    )) * Mat4::from_scale(0.2),
+                );
             }
         };
 
@@ -715,7 +832,7 @@ fn main() -> Result<()> {
             cam.speed /= 1.2;
             println!("Rychlost snížena na: {:.1}", cam.speed);
         }
-        
+
         // Obsluha klávesy Home - návrat na výchozí pozici pro aktuální režim
         if input_manager.is_key_pressed(KeyCode::Home) {
             if mode == CamMode::Spectator {
@@ -724,7 +841,8 @@ fn main() -> Result<()> {
                 reset_state.speed = cam.speed; // Zachová aktuální rychlost
                 reset_state.apply_to_camera(&mut cam);
                 println!("Kamera resetována na výchozí spectator pozici");
-            } else { // ThirdPerson
+            } else {
+                // ThirdPerson
                 // Vytvoření nového stavu kamery s výchozí pozicí, ale aktuální rychlostí kamery
                 let mut reset_state = CameraState::new(default_third_person_pos);
                 reset_state.speed = cam.speed; // Zachová aktuální rychlost
@@ -735,45 +853,50 @@ fn main() -> Result<()> {
 
         // Aktualizace kamery pomocí nové metody pro hladký pohyb
         cam.update_smooth(&input_manager, dt);
-        
+
         // Aktualizace stavů kamer a značek podle aktuálního režimu
         if mode == CamMode::Spectator {
             // Aktualizuj stav aktuální kamery (Spectator)
             spectator_state = CameraState::from_camera(&cam);
-            
+
             // Aktualizuj pozici značky aktuální kamery (Spectator)
-            spectator_glow.set_transformation(Mat4::from_translation(vec3(
-                spectator_state.pos.x, spectator_state.pos.y, spectator_state.pos.z
-            )) * Mat4::from_scale(0.2));
-            
+            spectator_glow.set_transformation(
+                Mat4::from_translation(vec3(
+                    spectator_state.pos.x,
+                    spectator_state.pos.y,
+                    spectator_state.pos.z,
+                )) * Mat4::from_scale(0.2),
+            );
+
             // Aktualizuj směrový paprsek pro spectator kameru
             if show_camera_direction {
                 // Získáme směrový vektor kamery a nastavíme transformaci paprsku
                 let dir = cam.dir();
-                
+
                 // Vytvoříme rotační matici, která natočí válec (který je standardně podél osy Y)
                 // ve směru pohledu kamery
-                
+
                 // 1. Vypočítáme úhel mezi osou Y a směrovým vektorem kamery
                 let y_axis = Vector3::unit_y();
                 let angle = y_axis.dot(dir).acos();
-                
+
                 // 2. Vypočítáme osu rotace (kolmou na rovinu obsahující osu Y a směrový vektor)
                 let rotation_axis = y_axis.cross(dir).normalize();
-                
+
                 // Vytvoření transformační matice pro válec
                 let scale = 0.05; // tenký válec
                 let length = 3.0; // délka paprsku
-                
+
                 // Vytvoření matice transformace
                 let translation = Mat4::from_translation(vec3(
-                    spectator_state.pos.x, 
-                    spectator_state.pos.y, 
-                    spectator_state.pos.z
+                    spectator_state.pos.x,
+                    spectator_state.pos.y,
+                    spectator_state.pos.z,
                 ));
-                
+
                 // Pokud je směrový vektor téměř rovnoběžný s osou Y, použijeme speciální zacházení
-                let rotation = if angle.abs() < 0.01 || (std::f32::consts::PI - angle).abs() < 0.01 {
+                let rotation = if angle.abs() < 0.01 || (std::f32::consts::PI - angle).abs() < 0.01
+                {
                     // Pro případ kdy je vektor téměř rovnoběžný s osou Y
                     if dir.y > 0.0 {
                         Mat4::identity() // směr už je podél osy Y
@@ -785,26 +908,30 @@ fn main() -> Result<()> {
                     // Normální případ - rotace kolem vypočtené osy
                     Mat4::from_axis_angle(
                         vec3(rotation_axis.x, rotation_axis.y, rotation_axis.z),
-                        Rad(angle)
+                        Rad(angle),
                     )
                 };
-                
+
                 // Měřítko - válec je standardně výšky 2.0, chceme jej natáhnout na délku `length`
                 // a zúžit na šířku `scale`
                 let scaling = Mat4::from_nonuniform_scale(scale, length / 2.0, scale);
-                
+
                 // Aplikujeme transformace v pořadí: měřítko, rotace, posun
                 camera_direction_ray.set_transformation(translation * rotation * scaling);
             }
         } else {
             // Aktualizuj stav aktuální kamery (ThirdPerson)
             third_person_state = CameraState::from_camera(&cam);
-            
+
             // Aktualizuj pozici značky aktuální kamery (ThirdPerson)
-            third_person_glow.set_transformation(Mat4::from_translation(vec3(
-                third_person_state.pos.x, third_person_state.pos.y, third_person_state.pos.z
-            )) * Mat4::from_scale(0.2));
-            
+            third_person_glow.set_transformation(
+                Mat4::from_translation(vec3(
+                    third_person_state.pos.x,
+                    third_person_state.pos.y,
+                    third_person_state.pos.z,
+                )) * Mat4::from_scale(0.2),
+            );
+
             // Když jsme v third person mode, zobrazíme směrový paprsek pro spectator kameru
             if show_camera_direction {
                 // Získáme směrový vektor kamery a nastavíme transformaci paprsku
@@ -812,28 +939,30 @@ fn main() -> Result<()> {
                 let dir = Vector3::new(
                     spectator_state.yaw.cos() * spectator_state.pitch.cos(),
                     spectator_state.pitch.sin(),
-                    spectator_state.yaw.sin() * spectator_state.pitch.cos()
-                ).normalize();
-                
+                    spectator_state.yaw.sin() * spectator_state.pitch.cos(),
+                )
+                .normalize();
+
                 // 1. Vypočítáme úhel mezi osou Y a směrovým vektorem kamery
                 let y_axis = Vector3::unit_y();
                 let angle = y_axis.dot(dir).acos();
-                
+
                 // 2. Vypočítáme osu rotace (kolmou na rovinu obsahující osu Y a směrový vektor)
                 let rotation_axis = y_axis.cross(dir).normalize();
-                
+
                 // Vytvoření transformační matice pro válec
                 let scale = 0.05; // tenký válec
                 let length = 3.0; // délka paprsku
-                // Vytvoření matice transformace
+                                  // Vytvoření matice transformace
                 let translation = Mat4::from_translation(vec3(
-                    spectator_state.pos.x, 
-                    spectator_state.pos.y, 
-                    spectator_state.pos.z
+                    spectator_state.pos.x,
+                    spectator_state.pos.y,
+                    spectator_state.pos.z,
                 ));
-                
+
                 // Pokud je směrový vektor téměř rovnoběžný s osou Y, použijeme speciální zacházení
-                let rotation = if angle.abs() < 0.01 || (std::f32::consts::PI - angle).abs() < 0.01 {
+                let rotation = if angle.abs() < 0.01 || (std::f32::consts::PI - angle).abs() < 0.01
+                {
                     // Pro případ kdy je vektor téměř rovnoběžný s osou Y
                     if dir.y > 0.0 {
                         Mat4::identity() // směr už je podél osy Y
@@ -845,14 +974,14 @@ fn main() -> Result<()> {
                     // Normální případ - rotace kolem vypočtené osy
                     Mat4::from_axis_angle(
                         vec3(rotation_axis.x, rotation_axis.y, rotation_axis.z),
-                        Rad(angle)
+                        Rad(angle),
                     )
                 };
-                
+
                 // Měřítko - válec - válec je standardně výšky 2.0, chceme jej natáhnout na délku `length`
                 // a zúžit na šířku `scale`
                 let scaling = Mat4::from_nonuniform_scale(scale, length / 2.0, scale);
-                
+
                 // Aplikujeme transformace v pořadí: měřítko, rotace, posun
                 camera_direction_ray.set_transformation(translation * rotation * scaling);
             }
@@ -860,7 +989,10 @@ fn main() -> Result<()> {
 
         // --- vykreslení ---
         let screen = frame_input.screen();
-        screen.clear(ClearState::color_and_depth(0.1, 0.1, 0.1, 1.0, 1.0));
+        // Clear the screen using the configured background color
+        screen.clear(ClearState::color_and_depth(
+            BG_COLOR.0, BG_COLOR.1, BG_COLOR.2, 1.0, 1.0,
+        ));
         let mut objects_to_render: Vec<&dyn Object> = Vec::new();
         objects_to_render.push(&base_model);
         // ... další objekty ...
@@ -875,7 +1007,8 @@ fn main() -> Result<()> {
                     if let Some(node) = find_node(root, sel_id) {
                         if let Some(ref plane) = node.plane {
                             // Vytvoř mesh dělící roviny pro vybraný uzel
-                            splitting_plane_mesh = Some(create_plane_mesh(plane, &node.bounds, &context));
+                            splitting_plane_mesh =
+                                Some(create_plane_mesh(plane, &node.bounds, &context));
                         }
                     }
                 }
@@ -885,7 +1018,11 @@ fn main() -> Result<()> {
             objects_to_render.push(plane_mesh);
         }
         // ... další objekty ...
-        screen.render(&cam.cam(frame_input.viewport), &objects_to_render, &[&ambient_light]);
+        screen.render(
+            &cam.cam(frame_input.viewport),
+            &objects_to_render,
+            &[&ambient_light],
+        );
         let _ = gui.render();
         FrameOutput::default()
     });


### PR DESCRIPTION
## Summary
- centralize tweakable colors and BSP limits in new `config.rs`
- use global colors for highlight, plane preview and background
- document mouse picking of BSP nodes in code

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a6346c5c832faa922fe525f6325f

## Summary by Sourcery

Centralize rendering parameters and BSP settings into a new configuration module, migrate hardcoded color and tree-depth values to configurable constants, and document mouse-based BSP node picking in the code

New Features:
- Introduce config.rs with background, highlight, and plane colors plus BSP depth and leaf-size limits

Enhancements:
- Replace hardcoded rendering colors and BSP limits with config constants throughout the code
- Add inline comments explaining mouse picking of BSP nodes
- Apply minor code formatting and cleanups