### PR TITLE
Visualize BSP tree in popup window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "cgmath",
  "egui",
+ "egui_plot",
  "glow",
  "gltf",
  "rayon",
@@ -544,6 +545,17 @@ dependencies = [
  "memoffset 0.9.1",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "egui_plot"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dca4871c15d51aadb79534dcf51a8189e5de3426ee7b465eb7db9a0a81ea67"
+dependencies = [
+ "ahash",
+ "egui",
+ "emath",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ rfd             = { version = "0.9", default-features = false, features = ["xdg-
 gltf            = { version = "1.4", features = ["extras", "names"] }
 rayon           = "1.10.0"
 glow = "0.14"
+egui_plot       = "0.29"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,111 @@
 use cgmath::InnerSpace;
+use std::collections::HashMap;
+use egui_plot::{Line, Plot, PlotPoint, Points, Text};
+
+struct TreePlotData {
+    positions: HashMap<usize, PlotPoint>,
+    lines: Vec<[PlotPoint; 2]>,
+}
+
+fn layout_bsp_tree(
+    node: &crate::bsp::BspNode,
+    depth: f64,
+    next_x: &mut f64,
+    data: &mut TreePlotData,
+) -> f64 {
+    let left = if let Some(ref front) = node.front {
+        Some(layout_bsp_tree(front, depth + 1.0, next_x, data))
+    } else {
+        None
+    };
+    let right = if let Some(ref back) = node.back {
+        Some(layout_bsp_tree(back, depth + 1.0, next_x, data))
+    } else {
+        None
+    };
+
+    let self_x = match (left, right) {
+        (Some(l), Some(r)) => (l + r) / 2.0,
+        (Some(l), None) => l,
+        (None, Some(r)) => r,
+        (None, None) => {
+            let x = *next_x;
+            *next_x += 1.0;
+            x
+        }
+    };
+
+    let self_point = PlotPoint { x: self_x, y: -depth };
+    data.positions.insert(node.id, self_point);
+
+    if let Some(ref front) = node.front {
+        if let Some(&child_point) = data.positions.get(&front.id) {
+            data.lines.push([self_point, child_point]);
+        }
+    }
+    if let Some(ref back) = node.back {
+        if let Some(&child_point) = data.positions.get(&back.id) {
+            data.lines.push([self_point, child_point]);
+        }
+    }
+
+    self_x
+}
+
+fn draw_bsp_tree_window(
+    ctx: &egui::Context,
+    open: &mut bool,
+    root: &crate::bsp::BspNode,
+    selected: &mut Option<usize>,
+) {
+    egui::Window::new("BSP Tree")
+        .open(open)
+        .vscroll(true)
+        .hscroll(true)
+        .show(ctx, |ui| {
+            let mut data = TreePlotData { positions: HashMap::new(), lines: Vec::new() };
+            let mut next_x = 0.0;
+            layout_bsp_tree(root, 0.0, &mut next_x, &mut data);
+
+            let plot = Plot::new("bsp_tree_plot").data_aspect(1.0);
+            let plot_resp = plot.show(ui, |plot_ui| {
+                for line in &data.lines {
+                    let pts = vec![[line[0].x, line[0].y], [line[1].x, line[1].y]];
+                    plot_ui.line(Line::new(pts).color(egui::Color32::LIGHT_GRAY));
+                }
+                for (&id, &pos) in &data.positions {
+                    let color = if selected == &Some(id) {
+                        egui::Color32::YELLOW
+                    } else {
+                        egui::Color32::LIGHT_BLUE
+                    };
+                    let pt = vec![[pos.x, pos.y]];
+                    plot_ui.points(Points::new(pt).radius(4.0).color(color));
+                    plot_ui.text(Text::new(pos, format!("{}", id)).anchor(egui::Align2::CENTER_CENTER));
+                }
+                plot_ui.pointer_coordinate()
+            });
+
+            if plot_resp.response.clicked() {
+                if let Some(pointer) = plot_resp.inner {
+                    let mut best = None;
+                    let mut best_dist = f64::INFINITY;
+                    for (&id, &p) in &data.positions {
+                        let dx = pointer.x - p.x;
+                        let dy = pointer.y - p.y;
+                        let d = dx * dx + dy * dy;
+                        if d < best_dist {
+                            best_dist = d;
+                            best = Some(id);
+                        }
+                    }
+                    if let Some(id) = best {
+                        *selected = Some(id);
+                    }
+                }
+            }
+        });
+}
 
 pub fn draw_left_panel(
     ctx: &egui::Context,
@@ -20,6 +127,7 @@ pub fn draw_left_panel(
     third_person_state: &mut crate::camera::CameraState,
     cam: &mut crate::camera::FreeCamera,
     current_stats: &crate::bsp::BspStats,
+    tree_window_open: &mut bool,
 ) {
     egui::SidePanel::left("tree").show(ctx, |side_ui| {
         egui::ScrollArea::vertical().show(side_ui, |ui| {
@@ -80,20 +188,9 @@ pub fn draw_left_panel(
             ui.separator();
             ui.heading("Struktura BSP stromu");
             ui.checkbox(show_splitting_plane, "Zobrazit dělící rovinu");
-
-            ui.separator();
-            ui.heading("Nastavení zobrazení");
-            ui.checkbox(disable_culling, "Zobrazit celý BSP strom (bez cullingu)");
-            if *disable_culling {
-                ui.label("Varování: Zobrazení celého stromu může zpomalit vykreslování.");
+            if ui.button("Otevřít vizualizaci").clicked() {
+                *tree_window_open = true;
             }
-            ui.checkbox(use_gpu_culling, "Použít GPU culling");
-            ui.checkbox(hide_selected, "Skrýt vybranou oblast");
-
-            egui::ScrollArea::vertical().show(ui, |ui| {
-                let root = bsp_root.as_ref().unwrap();
-                crate::bsp::render_bsp_tree(ui, root, selected_node);
-            });
 
             if let Some(node_id) = *selected_node {
                 if let Some(ref root) = *bsp_root {
@@ -118,6 +215,15 @@ pub fn draw_left_panel(
                     }
                 }
             }
+
+            ui.separator();
+            ui.heading("Nastavení zobrazení");
+            ui.checkbox(disable_culling, "Zobrazit celý BSP strom (bez cullingu)");
+            if *disable_culling {
+                ui.label("Varování: Zobrazení celého stromu může zpomalit vykreslování.");
+            }
+            ui.checkbox(use_gpu_culling, "Použít GPU culling");
+            ui.checkbox(hide_selected, "Skrýt vybranou oblast");
 
             ui.separator();
             ui.heading("BSP Statistiky");
@@ -201,4 +307,11 @@ pub fn draw_left_panel(
 
         });
     });
+    if *tree_window_open {
+        if let Some(ref root) = *bsp_root {
+            draw_bsp_tree_window(ctx, tree_window_open, root, selected_node);
+        } else {
+            *tree_window_open = false;
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,6 +450,7 @@ fn main() -> Result<()> {
     // Volba pro GPU akceleraci frustum cullingu
     let mut use_gpu_culling = false;
     let mut hide_selected_area = false;
+    let mut tree_window_open = false;
 
     // stav pro vykreslovaný mesh
     let _glb_path: Option<PathBuf> = None;
@@ -757,6 +758,7 @@ fn main() -> Result<()> {
                     &mut third_person_state,
                     &mut cam,
                     &current_stats,
+                    &mut tree_window_open,
                 );
             },
         );


### PR DESCRIPTION
## Summary
- Add pop-up BSP tree viewer using `egui_plot` to render nodes as a family-tree style diagram
- Open viewer from left panel and remove in-panel tree to avoid duplication
- Track `tree_window_open` state in main loop to manage the window

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a457a478ec832f9eac759438688b4b

## Summary by Sourcery

Implement a dedicated pop-up window for BSP tree visualization using egui_plot, refactor the left panel to open this window, remove the inline tree display, and track window state in the main loop

New Features:
- Add pop-up BSP tree viewer rendered as a family-tree diagram using egui_plot
- Provide a button in the left panel to open the BSP visualization window with interactive node selection

Enhancements:
- Remove the inline BSP tree display from the left panel to avoid duplication
- Manage the pop-up window's visibility via a tree_window_open state variable in the main loop

Build:
- Add egui_plot dependency for rendering the BSP tree visualization