### PR TITLE
Add GUI control for BSP branching limit

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use three_d::*;
 
 // Configuration values (colors and tree limits)
-use crate::config::{HIGHLIGHT_COLOR, MAX_BSP_DEPTH, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
+use crate::config::{HIGHLIGHT_COLOR, MAX_BSP_DEPTH, PLANE_COLOR};
 
 // ---------------- BSP Implementation -------------------------------------- //
 
@@ -283,11 +283,16 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
 }
 
 // Upravená funkce build_bsp, která přiřazuje ID uzlům
-pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> BspNode {
+pub fn build_bsp(
+    triangles: &[Triangle],
+    depth: u32,
+    next_id: &mut usize,
+    min_triangles_per_leaf: usize,
+) -> BspNode {
     let my_id = *next_id;
     *next_id += 1;
 
-    if depth >= MAX_BSP_DEPTH || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
+    if depth >= MAX_BSP_DEPTH || triangles.len() <= min_triangles_per_leaf {
         return BspNode::new_leaf(triangles.to_vec(), my_id);
     }
 
@@ -311,8 +316,8 @@ pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> Bsp
     }
 
     // Rekurzivní stavba podstromů - use sequential processing to fix ID assignment
-    let front_node = build_bsp(&front_triangles, depth + 1, next_id);
-    let back_node = build_bsp(&back_triangles, depth + 1, next_id);
+    let front_node = build_bsp(&front_triangles, depth + 1, next_id, min_triangles_per_leaf);
+    let back_node = build_bsp(&back_triangles, depth + 1, next_id, min_triangles_per_leaf);
 
     BspNode::new_node(splitting_plane, front_node, back_node, my_id)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,5 +16,5 @@ pub const PLANE_COLOR: Srgba = Srgba::new(200, 200, 50, 128);
 /// Maximum allowed depth when building the BSP tree.
 pub const MAX_BSP_DEPTH: u32 = 16;
 
-/// Minimum number of triangles inside a leaf before we stop splitting.
-pub const MIN_TRIANGLES_PER_LEAF: usize = 20;
+/// Default minimum number of triangles inside a leaf before we stop splitting.
+pub const DEFAULT_MIN_TRIANGLES_PER_LEAF: usize = 10;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -104,6 +104,7 @@ pub fn draw_left_panel(
     current_cpu_mesh: &mut three_d::CpuMesh,
     current_triangles: &mut Vec<crate::bsp::Triangle>,
     bsp_root: &mut Option<crate::bsp::BspNode>,
+    min_triangles_per_leaf: &mut usize,
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
     disable_culling: &mut bool,
@@ -171,9 +172,22 @@ pub fn draw_left_panel(
 
             ui.separator();
             ui.heading("Struktura BSP stromu");
+            let rebuild = ui
+                .add(egui::Slider::new(min_triangles_per_leaf, 1..=100).text("Limit větvení"))
+                .changed();
             ui.checkbox(show_splitting_plane, "Zobrazit dělící rovinu");
             if ui.button("Otevřít vizualizaci").clicked() {
                 *tree_window_open = true;
+            }
+            if rebuild {
+                let mut next_id = 0;
+                *bsp_root = Some(crate::bsp::build_bsp(
+                    current_triangles,
+                    0,
+                    &mut next_id,
+                    *min_triangles_per_leaf,
+                ));
+                *selected_node = None;
             }
 
             if let Some(node_id) = *selected_node {
@@ -341,7 +355,12 @@ pub fn draw_left_panel(
                         *file_loading = false;
                         *current_triangles = crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
                         let mut next_id = 0;
-                        *bsp_root = Some(crate::bsp::build_bsp(current_triangles, 0, &mut next_id));
+                        *bsp_root = Some(crate::bsp::build_bsp(
+                            current_triangles,
+                            0,
+                            &mut next_id,
+                            *min_triangles_per_leaf,
+                        ));
                     }
                     _ => {}
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use crate::bsp::{
     triangle_center, BspNode, BspStats, Frustum, Triangle,
 };
 use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
-use crate::config::BG_COLOR;
+use crate::config::{BG_COLOR, DEFAULT_MIN_TRIANGLES_PER_LEAF};
 use crate::gpu_job::GpuJob;
 use crate::input::{InputManager, KeyCode};
 
@@ -404,6 +404,7 @@ fn main() -> Result<()> {
     let mut current_triangles = cpu_mesh_to_triangles(&cpu_mesh);
     let mut file_loading = false;
     let mut gpu_job: Option<GpuJob> = None;
+    let mut min_triangles_per_leaf = DEFAULT_MIN_TRIANGLES_PER_LEAF;
 
     // Vytvoření triangles z CPU meshe
     println!("🔺 Převádím mesh na trojúhelníky...");
@@ -431,9 +432,10 @@ fn main() -> Result<()> {
     let tx_gui = tx.clone();
 
     // Spuštění stavby BSP stromu v jiném vlákně
+    let min_tris = min_triangles_per_leaf;
     thread::spawn(move || {
         let mut next_id = 0;
-        let tree = build_bsp(&triangles_clone, 0, &mut next_id);
+        let tree = build_bsp(&triangles_clone, 0, &mut next_id, min_tris);
         println!("✓ BSP strom sestaven s {} uzly", tree.count_nodes());
         tx.send(Message::InitialTree(tree)).unwrap();
     });
@@ -748,6 +750,7 @@ fn main() -> Result<()> {
                     &mut current_cpu_mesh,
                     &mut current_triangles,
                     &mut bsp_root,
+                    &mut min_triangles_per_leaf,
                     &mut selected_node,
                     &mut show_splitting_plane,
                     &mut disable_culling,


### PR DESCRIPTION
## Summary
- add GUI slider to limit BSP tree branching with default of 10 triangles per leaf
- parameterize BSP build function and propagate setting through main

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a47c67fed0832f8674eefee34fae96

## Summary by Sourcery

Add a GUI control for configuring the minimum triangles per BSP leaf and update the BSP builder to use this runtime parameter instead of a hardcoded value.

New Features:
- Add GUI slider to adjust BSP tree branching limit dynamically

Enhancements:
- Parameterize the build_bsp function with a user-defined min_triangles_per_leaf and propagate the setting through main and GUI