### PR TITLE
Add GUI control for BSP tree depth

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use three_d::*;
 
 // Configuration values (colors and tree limits)
-use crate::config::{HIGHLIGHT_COLOR, MAX_BSP_DEPTH, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
+use crate::config::{HIGHLIGHT_COLOR, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
 
 // ---------------- BSP Implementation -------------------------------------- //
 
@@ -283,11 +283,16 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
 }
 
 // Upravená funkce build_bsp, která přiřazuje ID uzlům
-pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> BspNode {
+pub fn build_bsp(
+    triangles: &[Triangle],
+    depth: u32,
+    max_depth: u32,
+    next_id: &mut usize,
+) -> BspNode {
     let my_id = *next_id;
     *next_id += 1;
 
-    if depth >= MAX_BSP_DEPTH || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
+    if depth >= max_depth || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
         return BspNode::new_leaf(triangles.to_vec(), my_id);
     }
 
@@ -311,8 +316,8 @@ pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> Bsp
     }
 
     // Rekurzivní stavba podstromů - use sequential processing to fix ID assignment
-    let front_node = build_bsp(&front_triangles, depth + 1, next_id);
-    let back_node = build_bsp(&back_triangles, depth + 1, next_id);
+    let front_node = build_bsp(&front_triangles, depth + 1, max_depth, next_id);
+    let back_node = build_bsp(&back_triangles, depth + 1, max_depth, next_id);
 
     BspNode::new_node(splitting_plane, front_node, back_node, my_id)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,8 +13,8 @@ pub const HIGHLIGHT_COLOR: Srgba = Srgba::new(255, 50, 50, 150);
 /// Color of the optional splitting plane preview.
 pub const PLANE_COLOR: Srgba = Srgba::new(200, 200, 50, 128);
 
-/// Maximum allowed depth when building the BSP tree.
-pub const MAX_BSP_DEPTH: u32 = 16;
+/// Default maximum depth when building the BSP tree.
+pub const DEFAULT_MAX_BSP_DEPTH: u32 = 10;
 
 /// Minimum number of triangles inside a leaf before we stop splitting.
 pub const MIN_TRIANGLES_PER_LEAF: usize = 20;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -116,6 +116,7 @@ pub fn draw_left_panel(
     cam: &mut crate::camera::FreeCamera,
     current_stats: &crate::bsp::BspStats,
     tree_window_open: &mut bool,
+    max_depth: &mut u32,
 ) {
     egui::SidePanel::left("tree").show(ctx, |side_ui| {
         egui::ScrollArea::vertical().show(side_ui, |ui| {
@@ -172,6 +173,18 @@ pub fn draw_left_panel(
             ui.separator();
             ui.heading("Struktura BSP stromu");
             ui.checkbox(show_splitting_plane, "Zobrazit dělící rovinu");
+            let depth_changed = ui
+                .add(egui::Slider::new(max_depth, 1..=32).text("Max. hloubka"))
+                .changed();
+            if depth_changed {
+                let mut next_id = 0;
+                *bsp_root = Some(crate::bsp::build_bsp(
+                    current_triangles,
+                    0,
+                    *max_depth,
+                    &mut next_id,
+                ));
+            }
             if ui.button("Otevřít vizualizaci").clicked() {
                 *tree_window_open = true;
             }
@@ -341,7 +354,12 @@ pub fn draw_left_panel(
                         *file_loading = false;
                         *current_triangles = crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
                         let mut next_id = 0;
-                        *bsp_root = Some(crate::bsp::build_bsp(current_triangles, 0, &mut next_id));
+                        *bsp_root = Some(crate::bsp::build_bsp(
+                            current_triangles,
+                            0,
+                            *max_depth,
+                            &mut next_id,
+                        ));
                     }
                     _ => {}
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use crate::bsp::{
     triangle_center, BspNode, BspStats, Frustum, Triangle,
 };
 use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
-use crate::config::BG_COLOR;
+use crate::config::{BG_COLOR, DEFAULT_MAX_BSP_DEPTH};
 use crate::gpu_job::GpuJob;
 use crate::input::{InputManager, KeyCode};
 
@@ -404,6 +404,7 @@ fn main() -> Result<()> {
     let mut current_triangles = cpu_mesh_to_triangles(&cpu_mesh);
     let mut file_loading = false;
     let mut gpu_job: Option<GpuJob> = None;
+    let mut max_depth = DEFAULT_MAX_BSP_DEPTH;
 
     // Vytvoření triangles z CPU meshe
     println!("🔺 Převádím mesh na trojúhelníky...");
@@ -431,9 +432,10 @@ fn main() -> Result<()> {
     let tx_gui = tx.clone();
 
     // Spuštění stavby BSP stromu v jiném vlákně
+    let max_depth_copy = max_depth;
     thread::spawn(move || {
         let mut next_id = 0;
-        let tree = build_bsp(&triangles_clone, 0, &mut next_id);
+        let tree = build_bsp(&triangles_clone, 0, max_depth_copy, &mut next_id);
         println!("✓ BSP strom sestaven s {} uzly", tree.count_nodes());
         tx.send(Message::InitialTree(tree)).unwrap();
     });
@@ -760,6 +762,7 @@ fn main() -> Result<()> {
                     &mut cam,
                     &current_stats,
                     &mut tree_window_open,
+                    &mut max_depth,
                 );
             },
         );


### PR DESCRIPTION
## Summary
- make BSP recursion depth configurable
- expose max depth slider in GUI with default of 10
- plumb max-depth setting through tree construction

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68a47c67fed0832f8674eefee34fae96

## Summary by Sourcery

Make BSP tree recursion depth configurable via GUI by adding a slider, plumbing the new max_depth setting through all build_bsp calls, and updating the default depth constant.

New Features:
- Add a slider in the GUI left panel to adjust BSP tree max recursion depth (1–32).

Enhancements:
- Propagate max_depth parameter through build_bsp calls, replacing the fixed compile-time limit.
- Rebuild the BSP tree automatically when the max_depth slider changes or a new mesh file is loaded.

Chores:
- Rename the MAX_BSP_DEPTH constant to DEFAULT_MAX_BSP_DEPTH and set its default to 10.