### PR TITLE
Add BSP branching limit control

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use three_d::*;
 
 // Configuration values (colors and tree limits)
-use crate::config::{HIGHLIGHT_COLOR, MAX_BSP_DEPTH, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
+use crate::config::{HIGHLIGHT_COLOR, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
 
 // ---------------- BSP Implementation -------------------------------------- //
 
@@ -283,11 +283,16 @@ fn bucketed_sah_plane(tris: &[Triangle], buckets: usize) -> Plane {
 }
 
 // Upravená funkce build_bsp, která přiřazuje ID uzlům
-pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> BspNode {
+pub fn build_bsp(
+    triangles: &[Triangle],
+    depth: u32,
+    max_depth: u32,
+    next_id: &mut usize,
+) -> BspNode {
     let my_id = *next_id;
     *next_id += 1;
 
-    if depth >= MAX_BSP_DEPTH || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
+    if depth >= max_depth || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
         return BspNode::new_leaf(triangles.to_vec(), my_id);
     }
 
@@ -311,8 +316,8 @@ pub fn build_bsp(triangles: &[Triangle], depth: u32, next_id: &mut usize) -> Bsp
     }
 
     // Rekurzivní stavba podstromů - use sequential processing to fix ID assignment
-    let front_node = build_bsp(&front_triangles, depth + 1, next_id);
-    let back_node = build_bsp(&back_triangles, depth + 1, next_id);
+    let front_node = build_bsp(&front_triangles, depth + 1, max_depth, next_id);
+    let back_node = build_bsp(&back_triangles, depth + 1, max_depth, next_id);
 
     BspNode::new_node(splitting_plane, front_node, back_node, my_id)
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,3 +1,4 @@
+use crate::config::MAX_BSP_DEPTH;
 use cgmath::InnerSpace;
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
 use std::collections::HashMap;
@@ -116,6 +117,7 @@ pub fn draw_left_panel(
     cam: &mut crate::camera::FreeCamera,
     current_stats: &crate::bsp::BspStats,
     tree_window_open: &mut bool,
+    branch_limit: &mut u32,
 ) {
     egui::SidePanel::left("tree").show(ctx, |side_ui| {
         egui::ScrollArea::vertical().show(side_ui, |ui| {
@@ -171,6 +173,7 @@ pub fn draw_left_panel(
 
             ui.separator();
             ui.heading("Struktura BSP stromu");
+            ui.add(egui::Slider::new(branch_limit, 1..=MAX_BSP_DEPTH).text("Limit větvení"));
             ui.checkbox(show_splitting_plane, "Zobrazit dělící rovinu");
             if ui.button("Otevřít vizualizaci").clicked() {
                 *tree_window_open = true;
@@ -341,7 +344,12 @@ pub fn draw_left_panel(
                         *file_loading = false;
                         *current_triangles = crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
                         let mut next_id = 0;
-                        *bsp_root = Some(crate::bsp::build_bsp(current_triangles, 0, &mut next_id));
+                        *bsp_root = Some(crate::bsp::build_bsp(
+                            current_triangles,
+                            0,
+                            *branch_limit,
+                            &mut next_id,
+                        ));
                     }
                     _ => {}
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,9 +431,11 @@ fn main() -> Result<()> {
     let tx_gui = tx.clone();
 
     // Spuštění stavby BSP stromu v jiném vlákně
+    let default_branch_limit = 7u32;
+    let branch_limit_clone = default_branch_limit;
     thread::spawn(move || {
         let mut next_id = 0;
-        let tree = build_bsp(&triangles_clone, 0, &mut next_id);
+        let tree = build_bsp(&triangles_clone, 0, branch_limit_clone, &mut next_id);
         println!("✓ BSP strom sestaven s {} uzly", tree.count_nodes());
         tx.send(Message::InitialTree(tree)).unwrap();
     });
@@ -452,6 +454,7 @@ fn main() -> Result<()> {
     let mut show_loaded_model = true;
     let mut show_selected_model = true;
     let mut tree_window_open = false;
+    let mut branch_limit = default_branch_limit;
 
     // stav pro vykreslovaný mesh
     let _glb_path: Option<PathBuf> = None;
@@ -560,16 +563,17 @@ fn main() -> Result<()> {
                 }
                 Message::NewFile {
                     cpu_mesh: new_cpu_mesh,
-                    triangles: new_triangles,
+                    triangles: _,
                     file_name,
                     load_status: _,
-                    bsp_tree,
+                    bsp_tree: _,
                 } => {
                     current_cpu_mesh = new_cpu_mesh;
-                    current_triangles = new_triangles;
                     loaded_file_name = file_name;
                     file_loading = false;
-                    bsp_root = Some(bsp_tree);
+                    current_triangles = cpu_mesh_to_triangles(&current_cpu_mesh);
+                    let mut next_id = 0;
+                    bsp_root = Some(build_bsp(&current_triangles, 0, branch_limit, &mut next_id));
                     total_stats.total_nodes = bsp_root.as_ref().unwrap().count_nodes();
                     total_stats.total_triangles = current_triangles.len() as u32;
                     unsafe {
@@ -760,6 +764,7 @@ fn main() -> Result<()> {
                     &mut cam,
                     &current_stats,
                     &mut tree_window_open,
+                    &mut branch_limit,
                 );
             },
         );


### PR DESCRIPTION
## Summary
- allow configuring maximum BSP depth from GUI (default 7)
- update BSP builder to respect user-defined depth limit
- rebuild tree with the specified limit when loading models

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68a48150cc54832fa9ef8c85a9c961fe

## Summary by Sourcery

Add user-configurable BSP tree depth limit and integrate it into the BSP builder and GUI

New Features:
- Expose a slider in the GUI to set the maximum BSP branching depth (default 7)
- Rebuild the BSP tree with the user-defined depth limit when loading models

Enhancements:
- Update build_bsp to accept and enforce a max_depth parameter
- Apply the max_depth setting in both initial threaded build and on model reload