### PR TITLE
Add configurable model color

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use three_d::*;
 
 // Configuration values (colors and tree limits)
-use crate::config::{HIGHLIGHT_COLOR, MIN_TRIANGLES_PER_LEAF, PLANE_COLOR};
+use crate::config::{HIGHLIGHT_COLOR, MIN_TRIANGLES_PER_LEAF, MODEL_COLOR, PLANE_COLOR};
 
 // ---------------- BSP Implementation -------------------------------------- //
 
@@ -756,7 +756,7 @@ fn create_material_and_model(
     let material = ColorMaterial::new_opaque(
         context,
         &CpuMaterial {
-            albedo: Srgba::new(100, 150, 255, 255), // Modrá barva aby byl model viditelný
+            albedo: MODEL_COLOR, // Modrá barva aby byl model viditelný
             ..Default::default()
         },
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,9 @@ use three_d::Srgba;
 /// Background color of the main render target (RGB 0.0‑1.0).
 pub const BG_COLOR: (f32, f32, f32) = (0.1, 0.1, 0.1);
 
+/// Color used for the loaded model.
+pub const MODEL_COLOR: Srgba = Srgba::new(100, 150, 255, 255);
+
 /// Color used to highlight the currently selected geometry.
 pub const HIGHLIGHT_COLOR: Srgba = Srgba::new(255, 50, 50, 150);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use crate::bsp::{
     triangle_center, BspNode, BspStats, Frustum, Triangle,
 };
 use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
-use crate::config::{BG_COLOR, DEFAULT_BRANCH_LIMIT};
+use crate::config::{BG_COLOR, DEFAULT_BRANCH_LIMIT, MODEL_COLOR};
 use crate::gpu_job::GpuJob;
 use crate::input::{InputManager, KeyCode};
 
@@ -317,7 +317,7 @@ fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, Co
     let material = ColorMaterial::new_opaque(
         context,
         &CpuMaterial {
-            albedo: Srgba::new(100, 150, 255, 255),
+            albedo: MODEL_COLOR,
             ..Default::default()
         },
     );
@@ -461,7 +461,7 @@ fn main() -> Result<()> {
     let material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(100, 150, 255, 255), // Modrá barva aby byl model viditelný
+            albedo: MODEL_COLOR, // Modrá barva aby byl model viditelný
             ..Default::default()
         },
     );


### PR DESCRIPTION
## Summary
- expose `MODEL_COLOR` constant for controlling the model color
- apply the constant throughout rendering code

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4905f4668832fa4ee058d343c3118

## Summary by Sourcery

Introduce a configurable MODEL_COLOR constant and apply it throughout the rendering code to replace hardcoded model color values.

New Features:
- Expose MODEL_COLOR constant in config for controlling the loaded model color

Enhancements:
- Replace hardcoded Srgba values with MODEL_COLOR in main rendering, mesh creation, and BSP material setup