### PR TITLE
Remove BSP tree disable-culling option

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -126,7 +126,6 @@ pub fn draw_left_panel(
     bsp_root: &mut Option<crate::bsp::BspNode>,
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
-    disable_culling: &mut bool,
     use_gpu_culling: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
@@ -233,10 +232,6 @@ pub fn draw_left_panel(
 
             ui.separator();
             ui.heading("Nastavení zobrazení");
-            ui.checkbox(disable_culling, "Zobrazit celý BSP strom (bez cullingu)");
-            if *disable_culling {
-                ui.label("Varování: Zobrazení celého stromu může zpomalit vykreslování.");
-            }
             ui.checkbox(use_gpu_culling, "Použít GPU culling");
             ui.checkbox(show_loaded_model, "Zobrazit načtený model");
             ui.checkbox(show_selected_model, "Zobrazit vybranou oblast");

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,8 +446,6 @@ fn main() -> Result<()> {
         ..Default::default()
     };
 
-    // Přidáme novou proměnnou pro vypnutí cullingu
-    let mut disable_culling = false;
     // Volba pro GPU akceleraci frustum cullingu
     let mut use_gpu_culling = false;
     let mut show_loaded_model = true;
@@ -660,13 +658,7 @@ fn main() -> Result<()> {
         };
 
         // Výběr culling metody
-        let visible_triangles = if disable_culling {
-            // If culling is disabled, render all triangles without traversing
-            // the BSP tree each frame.
-            current_stats.nodes_visited = current_stats.total_nodes;
-            current_stats.triangles_rendered = current_stats.total_triangles;
-            current_triangles.clone()
-        } else if use_gpu_culling {
+        let visible_triangles = if use_gpu_culling {
             if let Some(ref job) = gpu_job {
                 gpu_cull_triangles(job, &current_triangles, &frustum)
             } else {
@@ -754,7 +746,6 @@ fn main() -> Result<()> {
                     &mut bsp_root,
                     &mut selected_node,
                     &mut show_splitting_plane,
-                    &mut disable_culling,
                     &mut use_gpu_culling,
                     &mut show_loaded_model,
                     &mut show_selected_model,


### PR DESCRIPTION
## Summary
- drop the UI option to render the full BSP tree without culling
- simplify render path to always cull on CPU or GPU

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68a4cd1c76c8832f8ea8fe31c516d7dd

## Summary by Sourcery

Remove the disable-culling option for the BSP tree and streamline the rendering logic to consistently cull triangles using CPU or GPU.

Enhancements:
- Remove the UI and code support for disabling BSP tree culling
- Simplify the rendering path to always perform frustum culling on CPU or GPU