### PR TITLE
Add frustum culling toggle in UI

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -126,6 +126,7 @@ pub fn draw_left_panel(
     bsp_root: &mut Option<crate::bsp::BspNode>,
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
+    culling_enabled: &mut bool,
     use_gpu_culling: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
@@ -232,6 +233,7 @@ pub fn draw_left_panel(
 
             ui.separator();
             ui.heading("Nastavení zobrazení");
+            ui.checkbox(culling_enabled, "Povolit culling");
             ui.checkbox(use_gpu_culling, "Použít GPU culling");
             ui.checkbox(show_loaded_model, "Zobrazit načtený model");
             ui.checkbox(show_selected_model, "Zobrazit vybranou oblast");

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,6 +443,7 @@ fn main() -> Result<()> {
     };
 
     // Volba pro GPU akceleraci frustum cullingu
+    let mut culling_enabled = true;
     let mut use_gpu_culling = false;
     let mut show_loaded_model = true;
     let mut show_selected_model = true;
@@ -634,7 +635,11 @@ fn main() -> Result<()> {
         };
 
         // Výběr culling metody
-        let visible_triangles = if use_gpu_culling {
+        let visible_triangles = if !culling_enabled {
+            current_stats.nodes_visited = total_stats.total_nodes;
+            current_stats.triangles_rendered = total_stats.total_triangles;
+            current_triangles.clone()
+        } else if use_gpu_culling {
             if let Some(ref job) = gpu_job {
                 gpu_cull_triangles(job, &current_triangles, &frustum)
             } else {
@@ -673,6 +678,7 @@ fn main() -> Result<()> {
                     &mut bsp_root,
                     &mut selected_node,
                     &mut show_splitting_plane,
+                    &mut culling_enabled,
                     &mut use_gpu_culling,
                     &mut show_loaded_model,
                     &mut show_selected_model,


### PR DESCRIPTION
## Summary
- add checkbox to enable/disable frustum culling
- bypass culling logic when disabled and show all triangles

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68a88fbc7e74832f82545f8375f03a15

## Summary by Sourcery

Add a toggle in the UI to enable or disable frustum culling and adjust rendering logic to show all triangles when culling is turned off

New Features:
- Add UI checkbox to enable or disable frustum culling

Enhancements:
- Introduce culling_enabled flag and bypass frustum culling logic when disabled, rendering all triangles and updating stats accordingly