### PR TITLE
Fix rendering disappearing at steep camera angles

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -30,7 +30,12 @@ impl FreeCamera {
     }
 
     pub fn right(&self) -> Vector3<f32> {
-        self.dir().cross(Vector3::unit_y()).normalize()
+        let right = self.dir().cross(Vector3::unit_y());
+        if right.magnitude2() < 1e-6 {
+            Vector3::unit_x()
+        } else {
+            right.normalize()
+        }
     }
 
     pub fn update_smooth(&mut self, input_manager: &InputManager, dt: f32) {
@@ -62,11 +67,17 @@ impl FreeCamera {
     }
 
     pub fn cam(&self, vp: Viewport) -> Camera {
+        let dir = self.dir();
+        let up = if dir.x.abs() < 1e-4 && dir.z.abs() < 1e-4 {
+            Vector3::unit_z()
+        } else {
+            Vector3::unit_y()
+        };
         Camera::new_perspective(
             vp,
             self.pos,
-            self.pos + self.dir(),
-            Vector3::unit_y(),
+            self.pos + dir,
+            up,
             Deg(60.0),
             0.1,
             1000.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -613,11 +613,16 @@ fn main() -> Result<()> {
             )
             .normalize();
 
+            let spectator_up = if spectator_dir.x.abs() < 1e-4 && spectator_dir.z.abs() < 1e-4 {
+                Vector3::unit_z()
+            } else {
+                Vector3::unit_y()
+            };
             let spectator_camera = Camera::new_perspective(
                 frame_input.viewport,
                 spectator_state.pos,
                 spectator_state.pos + spectator_dir,
-                Vector3::unit_y(),
+                spectator_up,
                 Deg(60.0),
                 0.1,
                 1000.0,


### PR DESCRIPTION
## Summary
- avoid NaNs in FreeCamera right vector
- dynamically choose camera up vector to prevent view degeneracy
- apply same up logic to spectator frustum in third-person mode

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a8921f1ec8832faa40ed34c123f2f7

## Summary by Sourcery

Fix camera rendering issues at steep angles by handling edge cases in vector calculations to prevent NaNs and view degeneracy.

Bug Fixes:
- Avoid NaNs in FreeCamera right vector by falling back to a default axis when the cross product magnitude is near zero

Enhancements:
- Dynamically select the camera up vector based on view direction in both free and spectator cameras to prevent degeneracy when looking straight up or down