### PR TITLE
Ensure spectator state updates in third-person mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -954,6 +954,8 @@ fn main() -> Result<()> {
         } else {
             // Aktualizuj stav aktuální kamery (ThirdPerson)
             third_person_state = CameraState::from_camera(&cam);
+            // Synchronizuj spectator_state pro účely cullingu
+            spectator_state = third_person_state.clone();
 
             // Aktualizuj pozici značky aktuální kamery (ThirdPerson)
             third_person_glow.set_transformation(
@@ -961,6 +963,15 @@ fn main() -> Result<()> {
                     third_person_state.pos.x,
                     third_person_state.pos.y,
                     third_person_state.pos.z,
+                )) * Mat4::from_scale(0.2),
+            );
+
+            // Posuň i značku spectator kamery, aby odpovídala cullingu
+            spectator_glow.set_transformation(
+                Mat4::from_translation(vec3(
+                    spectator_state.pos.x,
+                    spectator_state.pos.y,
+                    spectator_state.pos.z,
                 )) * Mat4::from_scale(0.2),
             );
 


### PR DESCRIPTION
## Summary
- keep spectator and glow markers synced while in third-person
- maintain culling consistency by cloning camera state when switching views

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68a89d480d24832f9f33fb339e992b2d

## Summary by Sourcery

Synchronize spectator state and glow marker in third-person mode for consistent culling and view representation

Enhancements:
- Clone the third-person camera state into spectator_state to maintain culling consistency when switching to third-person view
- Update the spectator glow marker transformation to match the cloned camera state