### PR TITLE
Use dedicated third-person camera state

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // BSP and geometry utilities
-use cgmath::Vector3;
+use cgmath::{Vector3, Vector4};
 use rayon::prelude::*;
 use three_d::*;
 
@@ -951,74 +951,29 @@ pub struct Frustum {
 impl Frustum {
     pub fn from_camera(camera: &Camera) -> Self {
         // Získáme view-projection matici
-        let vp_matrix = camera.projection() * camera.view();
+        let m = camera.projection() * camera.view();
 
-        // Převedeme na pole - Matrix4 nemá as_slice(), musíme použít jiný přístup
-        let mat = [
-            vp_matrix.x.x,
-            vp_matrix.x.y,
-            vp_matrix.x.z,
-            vp_matrix.x.w,
-            vp_matrix.y.x,
-            vp_matrix.y.y,
-            vp_matrix.y.z,
-            vp_matrix.y.w,
-            vp_matrix.z.x,
-            vp_matrix.z.y,
-            vp_matrix.z.z,
-            vp_matrix.z.w,
-            vp_matrix.w.x,
-            vp_matrix.w.y,
-            vp_matrix.w.z,
-            vp_matrix.w.w,
+        // Pomocná funkce pro vytvoření roviny z Vector4
+        fn make_plane(v: Vector4<f32>) -> Plane {
+            let normal = Vector3::new(v.x, v.y, v.z);
+            let inv_len = 1.0 / normal.magnitude();
+            Plane {
+                n: normal * inv_len,
+                d: v.w * inv_len,
+            }
+        }
+
+        // Extrahujeme 6 rovin frustumu pomocí sloupců matice
+        let planes = [
+            make_plane(m.w + m.x), // Levá rovina
+            make_plane(m.w - m.x), // Pravá rovina
+            make_plane(m.w + m.y), // Spodní rovina
+            make_plane(m.w - m.y), // Horní rovina
+            make_plane(m.w + m.z), // Blízká rovina
+            make_plane(m.w - m.z), // Vzdálená rovina
         ];
 
-        // Extrahujeme 6 rovin frustumu
-        // Levá rovina
-        let left = Plane {
-            n: Vector3::new(mat[3] + mat[0], mat[7] + mat[4], mat[11] + mat[8]).normalize(),
-            d: (mat[15] + mat[12])
-                / (mat[3] + mat[0]).hypot((mat[7] + mat[4]).hypot(mat[11] + mat[8])),
-        };
-
-        // Pravá rovina
-        let right = Plane {
-            n: Vector3::new(mat[3] - mat[0], mat[7] - mat[4], mat[11] - mat[8]).normalize(),
-            d: (mat[15] - mat[12])
-                / (mat[3] - mat[0]).hypot((mat[7] - mat[4]).hypot(mat[11] - mat[8])),
-        };
-
-        // Spodní rovina
-        let bottom = Plane {
-            n: Vector3::new(mat[3] + mat[1], mat[7] + mat[5], mat[11] + mat[9]).normalize(),
-            d: (mat[15] + mat[13])
-                / (mat[3] + mat[1]).hypot((mat[7] + mat[5]).hypot(mat[11] + mat[9])),
-        };
-
-        // Horní rovina
-        let top = Plane {
-            n: Vector3::new(mat[3] - mat[1], mat[7] - mat[5], mat[11] - mat[9]).normalize(),
-            d: (mat[15] - mat[13])
-                / (mat[3] - mat[1]).hypot((mat[7] - mat[5]).hypot(mat[11] - mat[9])),
-        };
-
-        // Blízká rovina
-        let near = Plane {
-            n: Vector3::new(mat[3] + mat[2], mat[7] + mat[6], mat[11] + mat[10]).normalize(),
-            d: (mat[15] + mat[14])
-                / (mat[3] + mat[2]).hypot((mat[7] + mat[6]).hypot(mat[11] + mat[10])),
-        };
-
-        // Vzdálená rovina
-        let far = Plane {
-            n: Vector3::new(mat[3] - mat[2], mat[7] - mat[6], mat[11] - mat[10]).normalize(),
-            d: (mat[15] - mat[14])
-                / (mat[3] - mat[2]).hypot((mat[7] - mat[6]).hypot(mat[11] - mat[10])),
-        };
-
-        Frustum {
-            planes: [left, right, bottom, top, near, far],
-        }
+        Frustum { planes }
     }
 
     pub fn as_vec4_array(&self) -> [[f32; 4]; 6] {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -30,7 +30,12 @@ impl FreeCamera {
     }
 
     pub fn right(&self) -> Vector3<f32> {
-        self.dir().cross(Vector3::unit_y()).normalize()
+        let right = self.dir().cross(Vector3::unit_y());
+        if right.magnitude2() < 1e-6 {
+            Vector3::unit_x()
+        } else {
+            right.normalize()
+        }
     }
 
     pub fn update_smooth(&mut self, input_manager: &InputManager, dt: f32) {
@@ -62,11 +67,17 @@ impl FreeCamera {
     }
 
     pub fn cam(&self, vp: Viewport) -> Camera {
+        let dir = self.dir();
+        let up = if dir.x.abs() < 1e-4 && dir.z.abs() < 1e-4 {
+            Vector3::unit_z()
+        } else {
+            Vector3::unit_y()
+        };
         Camera::new_perspective(
             vp,
             self.pos,
-            self.pos + self.dir(),
-            Vector3::unit_y(),
+            self.pos + dir,
+            up,
             Deg(60.0),
             0.1,
             1000.0,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -126,6 +126,7 @@ pub fn draw_left_panel(
     bsp_root: &mut Option<crate::bsp::BspNode>,
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
+    culling_enabled: &mut bool,
     use_gpu_culling: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
@@ -232,6 +233,7 @@ pub fn draw_left_panel(
 
             ui.separator();
             ui.heading("Nastavení zobrazení");
+            ui.checkbox(culling_enabled, "Povolit culling");
             ui.checkbox(use_gpu_culling, "Použít GPU culling");
             ui.checkbox(show_loaded_model, "Zobrazit načtený model");
             ui.checkbox(show_selected_model, "Zobrazit vybranou oblast");

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,34 +600,35 @@ fn main() -> Result<()> {
         // Použij správnou pozici pozorovatele pro traverzování BSP stromu
         let observer_position = match mode {
             CamMode::Spectator => cam.pos, // V režimu Spectator používáme pozici kamery
-            CamMode::ThirdPerson => spectator_state.pos, // V režimu ThirdPerson používáme pozici Spectator kamery
+            CamMode::ThirdPerson => third_person_state.pos, // V režimu ThirdPerson používáme pozici ThirdPerson kamery
         };
 
-        // V třetí osobě vytvoříme frustum z pozice pozorovatele
+        // V třetí osobě vytvoříme frustum z pozice third person kamery
         let frustum = if mode == CamMode::ThirdPerson {
-            // Vytvoříme kameru z pozice spectator
-            let spectator_dir = Vector3::new(
-                spectator_state.yaw.cos() * spectator_state.pitch.cos(),
-                spectator_state.pitch.sin(),
-                spectator_state.yaw.sin() * spectator_state.pitch.cos(),
+            // Vytvoříme kameru z pozice third person
+            let third_person_dir = Vector3::new(
+                third_person_state.yaw.cos() * third_person_state.pitch.cos(),
+                third_person_state.pitch.sin(),
+                third_person_state.yaw.sin() * third_person_state.pitch.cos(),
             )
             .normalize();
 
-            let spectator_up = if spectator_dir.x.abs() < 1e-4 && spectator_dir.z.abs() < 1e-4 {
-                Vector3::unit_z()
-            } else {
-                Vector3::unit_y()
-            };
-            let spectator_camera = Camera::new_perspective(
+            let third_person_up =
+                if third_person_dir.x.abs() < 1e-4 && third_person_dir.z.abs() < 1e-4 {
+                    Vector3::unit_z()
+                } else {
+                    Vector3::unit_y()
+                };
+            let third_person_camera = Camera::new_perspective(
                 frame_input.viewport,
-                spectator_state.pos,
-                spectator_state.pos + spectator_dir,
-                spectator_up,
+                third_person_state.pos,
+                third_person_state.pos + third_person_dir,
+                third_person_up,
                 Deg(60.0),
                 0.1,
                 1000.0,
             );
-            Frustum::from_camera(&spectator_camera)
+            Frustum::from_camera(&third_person_camera)
         } else {
             Frustum::from_camera(&camera_obj)
         };
@@ -954,8 +955,6 @@ fn main() -> Result<()> {
         } else {
             // Aktualizuj stav aktuální kamery (ThirdPerson)
             third_person_state = CameraState::from_camera(&cam);
-            // Synchronizuj spectator_state pro účely cullingu
-            spectator_state = third_person_state.clone();
 
             // Aktualizuj pozici značky aktuální kamery (ThirdPerson)
             third_person_glow.set_transformation(

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,6 +443,7 @@ fn main() -> Result<()> {
     };
 
     // Volba pro GPU akceleraci frustum cullingu
+    let mut culling_enabled = true;
     let mut use_gpu_culling = false;
     let mut show_loaded_model = true;
     let mut show_selected_model = true;
@@ -634,7 +635,11 @@ fn main() -> Result<()> {
         };
 
         // Výběr culling metody
-        let visible_triangles = if use_gpu_culling {
+        let visible_triangles = if !culling_enabled {
+            current_stats.nodes_visited = total_stats.total_nodes;
+            current_stats.triangles_rendered = total_stats.total_triangles;
+            current_triangles.clone()
+        } else if use_gpu_culling {
             if let Some(ref job) = gpu_job {
                 gpu_cull_triangles(job, &current_triangles, &frustum)
             } else {
@@ -673,6 +678,7 @@ fn main() -> Result<()> {
                     &mut bsp_root,
                     &mut selected_node,
                     &mut show_splitting_plane,
+                    &mut culling_enabled,
                     &mut use_gpu_culling,
                     &mut show_loaded_model,
                     &mut show_selected_model,

--- a/src/main.rs
+++ b/src/main.rs
@@ -954,6 +954,8 @@ fn main() -> Result<()> {
         } else {
             // Aktualizuj stav aktuální kamery (ThirdPerson)
             third_person_state = CameraState::from_camera(&cam);
+            // Synchronizuj spectator_state pro účely cullingu
+            spectator_state = third_person_state.clone();
 
             // Aktualizuj pozici značky aktuální kamery (ThirdPerson)
             third_person_glow.set_transformation(
@@ -961,6 +963,15 @@ fn main() -> Result<()> {
                     third_person_state.pos.x,
                     third_person_state.pos.y,
                     third_person_state.pos.z,
+                )) * Mat4::from_scale(0.2),
+            );
+
+            // Posuň i značku spectator kamery, aby odpovídala cullingu
+            spectator_glow.set_transformation(
+                Mat4::from_translation(vec3(
+                    spectator_state.pos.x,
+                    spectator_state.pos.y,
+                    spectator_state.pos.z,
                 )) * Mat4::from_scale(0.2),
             );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -613,11 +613,16 @@ fn main() -> Result<()> {
             )
             .normalize();
 
+            let spectator_up = if spectator_dir.x.abs() < 1e-4 && spectator_dir.z.abs() < 1e-4 {
+                Vector3::unit_z()
+            } else {
+                Vector3::unit_y()
+            };
             let spectator_camera = Camera::new_perspective(
                 frame_input.viewport,
                 spectator_state.pos,
                 spectator_state.pos + spectator_dir,
-                Vector3::unit_y(),
+                spectator_up,
                 Deg(60.0),
                 0.1,
                 1000.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,49 +280,45 @@ fn process_primitive(
     Ok(())
 }
 
-// Funkce pro vytvoření meshe z viditelných trojúhelníků
-fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
-    // Paralelní zpracování pozic a indexů
+// Aktualizuje pozice a indexy viditelných trojúhelníků v předalokovaných bufferech
+fn create_visible_mesh(
+    triangles: &[Triangle],
+    positions: &mut Vec<Vec3>,
+    indices: &mut Vec<u32>,
+    mesh: &mut Mesh,
+) {
     let triangles_count = triangles.len();
 
-    // Paralelně vytvoříme pozice vrcholů
-    let positions: Vec<Vec3> = triangles
-        .par_iter()
-        .flat_map(|tri| {
-            vec![
-                vec3(tri.a.x, tri.a.y, tri.a.z),
-                vec3(tri.b.x, tri.b.y, tri.b.z),
-                vec3(tri.c.x, tri.c.y, tri.c.z),
-            ]
-        })
-        .collect();
+    // Připravíme buffery pro pozice
+    positions.clear();
+    positions.resize(triangles_count * 3, vec3(0.0, 0.0, 0.0));
+    positions
+        .par_chunks_mut(3)
+        .zip(triangles.par_iter())
+        .for_each(|(chunk, tri)| {
+            chunk[0] = vec3(tri.a.x, tri.a.y, tri.a.z);
+            chunk[1] = vec3(tri.b.x, tri.b.y, tri.b.z);
+            chunk[2] = vec3(tri.c.x, tri.c.y, tri.c.z);
+        });
 
-    // Paralelně vygenerujeme indexy
-    let indices: Vec<u32> = (0..triangles_count as u32)
-        .into_par_iter()
-        .flat_map(|i| {
-            let base_idx = i * 3;
-            vec![base_idx, base_idx + 1, base_idx + 2]
-        })
-        .collect();
+    // Připravíme buffery pro indexy
+    indices.clear();
+    indices.resize(triangles_count * 3, 0);
+    indices
+        .par_chunks_mut(3)
+        .enumerate()
+        .for_each(|(i, chunk)| {
+            let base_idx = i as u32 * 3;
+            chunk[0] = base_idx;
+            chunk[1] = base_idx + 1;
+            chunk[2] = base_idx + 2;
+        });
 
-    // Vytvoření nového meshe
-    let visible_mesh = CpuMesh {
-        positions: Positions::F32(positions),
-        indices: Indices::U32(indices),
-        ..Default::default()
-    };
-
-    // Vytvoření materiálu a modelu
-    let material = ColorMaterial::new_opaque(
-        context,
-        &CpuMaterial {
-            albedo: MODEL_COLOR,
-            ..Default::default()
-        },
-    );
-
-    Gm::new(Mesh::new(context, &visible_mesh), material)
+    // Aktualizace GPU bufferů
+    mesh.positions_mut().fill(positions);
+    if let IndexBuffer::U32(buffer) = mesh.indices_mut() {
+        buffer.fill(indices);
+    }
 }
 
 fn gpu_cull_triangles(job: &GpuJob, tris: &[Triangle], frustum: &Frustum) -> Vec<Triangle> {
@@ -463,7 +459,16 @@ fn main() -> Result<()> {
             ..Default::default()
         },
     );
-    let _model = Gm::new(Mesh::new(&context, &cpu_mesh), material.clone());
+    // Persistentní mesh a jeho CPU buffery
+    let placeholder = CpuMesh {
+        positions: Positions::F32(vec![vec3(0.0, 0.0, 0.0); 3]),
+        indices: Indices::U32(vec![0, 1, 2]),
+        ..Default::default()
+    };
+    let mut base_model = Gm::new(Mesh::new(&context, &placeholder), material);
+    let mut base_model_visible = false;
+    let mut visible_positions: Vec<Vec3> = Vec::with_capacity(triangles.len() * 3);
+    let mut visible_indices: Vec<u32> = Vec::with_capacity(triangles.len() * 3);
 
     // Glow efekty pro pozice kamer
     let glow_mesh = CpuMesh::sphere(16);
@@ -760,11 +765,17 @@ fn main() -> Result<()> {
             }
         }
 
-        let base_model = if !normal_tris.is_empty() {
-            Some(create_visible_mesh(&normal_tris, &context))
+        if !normal_tris.is_empty() {
+            create_visible_mesh(
+                &normal_tris,
+                &mut visible_positions,
+                &mut visible_indices,
+                &mut base_model.geometry,
+            );
+            base_model_visible = true;
         } else {
-            None
-        };
+            base_model_visible = false;
+        }
         let highlight_model = if !highlight_tris.is_empty() {
             Some(create_highlight_mesh(&highlight_tris, &context))
         } else {
@@ -1004,8 +1015,8 @@ fn main() -> Result<()> {
             BG_COLOR.0, BG_COLOR.1, BG_COLOR.2, 1.0, 1.0,
         ));
         let mut objects_to_render: Vec<&dyn Object> = Vec::new();
-        if let Some(ref base) = base_model {
-            objects_to_render.push(base);
+        if base_model_visible {
+            objects_to_render.push(&base_model);
         }
         if let Some(ref h) = highlight_model {
             objects_to_render.push(h);


### PR DESCRIPTION
## Summary
- use `third_person_state` for observer and frustum calculations in third-person mode
- stop overwriting `spectator_state` while the third-person camera is active
- rely on stored camera states to restore each mode's previous position when switching

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68a8a130e938832fa2661c862f3b4336

## Summary by Sourcery

Use a separate third-person camera state for observer positioning and frustum calculations, and preserve the spectator camera state when switching modes.

Enhancements:
- Introduce and use third_person_state.pos instead of spectator_state.pos for CamMode::ThirdPerson observer position and frustum creation
- Stop synchronizing spectator_state during third-person mode to avoid overwriting the spectator camera
- Retain each camera mode’s last known position by relying on distinct stored camera states