### PR TITLE
Add option to disable culling

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -127,6 +127,7 @@ pub fn draw_left_panel(
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
     use_gpu_culling: &mut bool,
+    disable_culling: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
     show_camera_direction: &mut bool,
@@ -234,7 +235,10 @@ pub fn draw_left_panel(
 
             ui.separator();
             ui.heading("Nastavení zobrazení");
-            ui.checkbox(use_gpu_culling, "Použít GPU culling");
+            ui.checkbox(disable_culling, "Vypnout culling");
+            ui.add_enabled_ui(!*disable_culling, |ui| {
+                ui.checkbox(use_gpu_culling, "Použít GPU culling");
+            });
             ui.checkbox(show_loaded_model, "Zobrazit načtený model");
             ui.checkbox(show_selected_model, "Zobrazit vybranou oblast");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,6 +449,7 @@ fn main() -> Result<()> {
 
     // Volba pro GPU akceleraci frustum cullingu
     let mut use_gpu_culling = false;
+    let mut disable_culling = false;
     let mut show_loaded_model = true;
     let mut show_selected_model = true;
     let mut tree_window_open = false;
@@ -649,7 +650,11 @@ fn main() -> Result<()> {
         };
 
         // Výběr culling metody
-        let visible_triangles = if use_gpu_culling {
+        let visible_triangles = if disable_culling {
+            current_stats.nodes_visited = current_stats.total_nodes;
+            current_stats.triangles_rendered = current_triangles.len() as u32;
+            current_triangles.clone()
+        } else if use_gpu_culling {
             if let Some(ref job) = gpu_job {
                 gpu_cull_triangles(job, &current_triangles, &frustum)
             } else {
@@ -694,6 +699,7 @@ fn main() -> Result<()> {
                     &mut selected_node,
                     &mut show_splitting_plane,
                     &mut use_gpu_culling,
+                    &mut disable_culling,
                     &mut show_loaded_model,
                     &mut show_selected_model,
                     &mut show_camera_direction,


### PR DESCRIPTION
## Summary
- Add `disable_culling` flag and GUI control to toggle it
- Render all triangles and update stats when culling is disabled

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c0317cd8832f9b4369a89ecc33d1

## Summary by Sourcery

Introduce a disable_culling option to bypass frustum culling, render all triangles, and update rendering statistics accordingly

New Features:
- Add disable_culling flag in the rendering loop to skip all culling methods
- Expose a "Vypnout culling" checkbox in the GUI to toggle the disable_culling flag

Enhancements:
- Automatically render all triangles and set nodes_visited and triangles_rendered stats when culling is disabled
- Disable the GPU culling checkbox when disable_culling is active to prevent conflicting options