### PR TITLE
Enable GPU culling and speed up mesh processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ gltf            = { version = "1.4", features = ["extras", "names"] }
 rayon           = "1.10.0"
 glow = "0.14"
 egui_plot       = "0.29"
+
+[profile.release]
+codegen-units = 1
+lto = "fat"
+panic = "abort"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with `egui` for the user interface.
 
 - Loads `GLTF`/`GLB` files and converts them to a simple triangle list.
 - Builds a BSP tree in a background thread so the UI stays responsive.
-- CPU or optional GPU accelerated frustum culling of triangles.
+- CPU or optional GPU accelerated frustum culling of triangles (enabled by default when supported).
 - Two camera modes – *Spectator* and *ThirdPerson* – with smooth controls.
 - Interactive UI for exploring the BSP structure and basic statistics.
 
@@ -21,10 +21,10 @@ This project is managed with Cargo.  To compile it simply run
 cargo build
 ```
 
-or to run it directly
+For the best performance, run the viewer in release mode:
 
 ```bash
-cargo run
+cargo run --release
 ```
 
 The binary opens a window showing the loaded scene.  On the first start the

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -567,101 +567,70 @@ pub fn create_plane_mesh(
 
 // ---------------- Free‑fly kamera ---------------------------------------- //
 pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
-    let mut triangles = Vec::with_capacity(mesh.positions.len() / 3);
-
     // Získáme pozice vrcholů z meshe
     let positions = match &mesh.positions {
         Positions::F32(pos) => pos,
         _ => return Vec::new(), // Pokud nemáme F32 pozice, vrátíme prázdný vektor
     };
 
-    // Zpracujeme indexy, pokud existují
     match &mesh.indices {
-        Indices::U32(indices) => {
-            // Pro každou trojici indexů vytvoříme trojúhelník
-            for i in (0..indices.len()).step_by(3) {
-                if i + 2 < indices.len() {
-                    let a_idx = indices[i] as usize;
-                    let b_idx = indices[i + 1] as usize;
-                    let c_idx = indices[i + 2] as usize;
-
-                    // Kontrola, zda indexy jsou v rozsahu
-                    if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len()
-                    {
-                        let a = Vector3::new(
-                            positions[a_idx].x,
-                            positions[a_idx].y,
-                            positions[a_idx].z,
-                        );
-                        let b = Vector3::new(
-                            positions[b_idx].x,
-                            positions[b_idx].y,
-                            positions[b_idx].z,
-                        );
-                        let c = Vector3::new(
-                            positions[c_idx].x,
-                            positions[c_idx].y,
-                            positions[c_idx].z,
-                        );
-
-                        triangles.push(Triangle { a, b, c });
-                    }
+        Indices::U32(indices) => indices
+            .par_chunks(3)
+            .filter_map(|chunk| {
+                if chunk.len() < 3 {
+                    return None;
                 }
-            }
-        }
-        Indices::U16(indices) => {
-            // Pro každou trojici indexů vytvoříme trojúhelník
-            for i in (0..indices.len()).step_by(3) {
-                if i + 2 < indices.len() {
-                    let a_idx = indices[i] as usize;
-                    let b_idx = indices[i + 1] as usize;
-                    let c_idx = indices[i + 2] as usize;
+                let a_idx = chunk[0] as usize;
+                let b_idx = chunk[1] as usize;
+                let c_idx = chunk[2] as usize;
 
-                    // Kontrola, zda indexy jsou v rozsahu
-                    if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len()
-                    {
-                        let a = Vector3::new(
-                            positions[a_idx].x,
-                            positions[a_idx].y,
-                            positions[a_idx].z,
-                        );
-                        let b = Vector3::new(
-                            positions[b_idx].x,
-                            positions[b_idx].y,
-                            positions[b_idx].z,
-                        );
-                        let c = Vector3::new(
-                            positions[c_idx].x,
-                            positions[c_idx].y,
-                            positions[c_idx].z,
-                        );
-
-                        triangles.push(Triangle { a, b, c });
-                    }
+                if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
+                    Some(Triangle {
+                        a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
+                        b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
+                        c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
+                    })
+                } else {
+                    None
                 }
-            }
-        }
-        Indices::None => {
-            // Pokud nemáme indexy, předpokládáme, že pozice jsou přímo vrcholy trojúhelníků
-            for i in (0..positions.len()).step_by(3) {
-                if i + 2 < positions.len() {
-                    let a = Vector3::new(positions[i].x, positions[i].y, positions[i].z);
-                    let b =
-                        Vector3::new(positions[i + 1].x, positions[i + 1].y, positions[i + 1].z);
-                    let c =
-                        Vector3::new(positions[i + 2].x, positions[i + 2].y, positions[i + 2].z);
-
-                    triangles.push(Triangle { a, b, c });
+            })
+            .collect(),
+        Indices::U16(indices) => indices
+            .par_chunks(3)
+            .filter_map(|chunk| {
+                if chunk.len() < 3 {
+                    return None;
                 }
-            }
-        }
-        _ => {
-            // Přidáno pro pokrytí všech případů
-            return Vec::new();
-        }
+                let a_idx = chunk[0] as usize;
+                let b_idx = chunk[1] as usize;
+                let c_idx = chunk[2] as usize;
+
+                if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
+                    Some(Triangle {
+                        a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
+                        b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
+                        c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect(),
+        Indices::None => positions
+            .par_chunks(3)
+            .filter_map(|chunk| {
+                if chunk.len() < 3 {
+                    return None;
+                }
+                Some(Triangle {
+                    a: Vector3::new(chunk[0].x, chunk[0].y, chunk[0].z),
+                    b: Vector3::new(chunk[1].x, chunk[1].y, chunk[1].z),
+                    c: Vector3::new(chunk[2].x, chunk[2].y, chunk[2].z),
+                })
+            })
+            .collect(),
+        _ => Vec::new(), // Přidáno pro pokrytí všech případů
     }
-
-    triangles
 }
 
 // Funkce pro traverzování BSP stromu s frustum cullingem

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,7 @@ fn main() -> Result<()> {
     let mut current_cpu_mesh = cpu_mesh.clone();
     let mut current_triangles = cpu_mesh_to_triangles(&cpu_mesh);
     let mut file_loading = false;
-    let mut gpu_job: Option<GpuJob> = None;
+    let mut gpu_job: Option<GpuJob>;
 
     // Vytvoření triangles z CPU meshe
     println!("🔺 Převádím mesh na trojúhelníky...");
@@ -448,7 +448,7 @@ fn main() -> Result<()> {
     };
 
     // Volba pro GPU akceleraci frustum cullingu
-    let mut use_gpu_culling = false;
+    let mut use_gpu_culling = gpu_job.is_some();
     let mut disable_culling = false;
     let mut show_loaded_model = true;
     let mut show_selected_model = true;


### PR DESCRIPTION
## Summary
- Enable GPU-based frustum culling by default when the compute shader is available
- Parallelize CPU mesh to triangle conversion using Rayon for faster preprocessing
- Add optimized release profile and document running in release mode

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68a8c56fe0dc832fbbb512deaf365a2f

## Summary by Sourcery

Enable GPU frustum culling by default when supported, parallelize mesh-to-triangle conversion for faster preprocessing, and introduce an optimized release profile with updated documentation.

New Features:
- Enable GPU-based frustum culling by default when a compute shader is available.

Enhancements:
- Parallelize CPU mesh-to-triangle conversion using Rayon for improved performance.
- Add an optimized release profile (single codegen unit, fat LTO, abort on panic).
- Default the GPU culling toggle based on GPU job availability in the application.

Documentation:
- Update README to reflect default GPU culling behavior and recommend running in release mode.