### PR TITLE
Expose pick traversal count in BSP statistics

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -62,6 +62,8 @@ pub struct BspStats {
     pub triangles_rendered: u32,
     pub total_nodes: u32,
     pub total_triangles: u32,
+    /// Počet uzlů navštívených při posledním výběru uzlu
+    pub nodes_to_selected: u32,
 }
 
 impl BspNode {
@@ -361,17 +363,19 @@ pub fn find_node_path<'a>(
 pub fn find_deepest_node_containing_point<'a>(
     node: &'a BspNode,
     point: Vector3<f32>,
+    visited: &mut u32,
 ) -> Option<&'a BspNode> {
+    *visited += 1;
     if !node.bounds.contains(point) {
         return None;
     }
     if let Some(ref front) = node.front {
-        if let Some(n) = find_deepest_node_containing_point(front, point) {
+        if let Some(n) = find_deepest_node_containing_point(front, point, visited) {
             return Some(n);
         }
     }
     if let Some(ref back) = node.back {
-        if let Some(n) = find_deepest_node_containing_point(back, point) {
+        if let Some(n) = find_deepest_node_containing_point(back, point, visited) {
             return Some(n);
         }
     }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -251,6 +251,10 @@ pub fn draw_left_panel(
             ));
             ui.label(format!("Navštíveno uzlů: {}", current_stats.nodes_visited));
             ui.label(format!(
+                "K výběru navštíveno uzlů: {}",
+                current_stats.nodes_to_selected
+            ));
+            ui.label(format!(
                 "Vykresleno trojúhelníků: {}",
                 current_stats.triangles_rendered
             ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -548,6 +548,8 @@ fn main() -> Result<()> {
     // Stav pro interaktivní výběr BSP:
     // ----------------------------------------------------------------------------
     let mut selected_node: Option<usize> = None;
+    // Počet uzlů navštívených při posledním hledání vybraného uzlu
+    let mut last_pick_visits: u32 = 0;
     let mut show_splitting_plane: bool = true;
 
     window.render_loop(move |mut frame_input| {
@@ -679,6 +681,8 @@ fn main() -> Result<()> {
             tris
         };
 
+        current_stats.nodes_to_selected = last_pick_visits;
+
         // --- GUI ---
         gui.update(
             events,
@@ -744,9 +748,13 @@ fn main() -> Result<()> {
                     let pick_mesh = Mesh::new(&context, &current_cpu_mesh);
                     if let Some(hit) = three_d::pick(&context, &camera_obj, pos, [&pick_mesh]) {
                         let p = Vector3::new(hit.position.x, hit.position.y, hit.position.z);
-                        if let Some(node) = find_deepest_node_containing_point(root, p) {
+                        let mut visited = 0;
+                        if let Some(node) =
+                            find_deepest_node_containing_point(root, p, &mut visited)
+                        {
                             selected_node = Some(node.id);
                         }
+                        last_pick_visits = visited;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- track number of BSP nodes visited when finding a picked node
- show visited count in GUI BSP statistics panel

## Testing
- `cargo test --color=never`

------
https://chatgpt.com/codex/tasks/task_e_68a8d2382a2c832fa4875e5b15fe47be

## Summary by Sourcery

Track and expose the number of BSP nodes visited during object pick operations in the GUI statistics panel

Enhancements:
- Add nodes_to_selected field to BspStats to capture the number of BSP nodes visited during pick operations
- Extend find_deepest_node_containing_point to accept and increment a visitation counter
- Record the visited node count in main and propagate it to the BSP statistics
- Update the GUI statistics panel to display the pick traversal count