### PR TITLE
Show subtree triangle count for selected BSP node

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -110,6 +110,10 @@ impl BspNode {
             + self.front.as_ref().map_or(0, |n| n.count_triangles())
             + self.back.as_ref().map_or(0, |n| n.count_triangles())
     }
+
+    pub fn subtree_triangles(&self) -> u32 {
+        self.subtree_tris
+    }
 }
 
 fn plane_from_triangle(tri: &Triangle) -> Plane {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -207,7 +207,7 @@ pub fn draw_left_panel(
                         ui.separator();
                         ui.heading("Vybraný uzel");
                         ui.label(format!("ID: {}", node.id));
-                        ui.label(format!("Trojúhelníků: {}", node.triangles.len()));
+                        ui.label(format!("Trojúhelníků: {}", node.subtree_triangles()));
                         if let Some(ref plane) = node.plane {
                             ui.label("Dělící rovina:");
                             ui.label(format!(
@@ -218,15 +218,6 @@ pub fn draw_left_panel(
                         } else {
                             ui.label("List (bez dělící roviny)");
                         }
-                        ui.label("Obalový objem:");
-                        ui.label(format!(
-                            "Min: ({:.2}, {:.2}, {:.2})",
-                            node.bounds.min.x, node.bounds.min.y, node.bounds.min.z
-                        ));
-                        ui.label(format!(
-                            "Max: ({:.2}, {:.2}, {:.2})",
-                            node.bounds.max.x, node.bounds.max.y, node.bounds.max.z
-                        ));
                         if ui.button("Odznačit").clicked() {
                             *selected_node = None;
                         }


### PR DESCRIPTION
## Summary
- Display the total triangles contained in a selected BSP node's subtree
- Remove bounding volume details from the node info panel

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d86f4348832faba1508470d5300f

## Summary by Sourcery

Show total triangles in a selected BSP node's subtree in the GUI and remove bounding volume details, using a new subtree_triangles() method on BspNode.

New Features:
- Display total triangle count of a selected BSP node's entire subtree in the left panel

Enhancements:
- Add BspNode::subtree_triangles() accessor for subtree triangle counts
- Remove bounding volume min/max information from the node info panel