### PR TITLE
Add help popup for selected BSP node

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -138,6 +138,7 @@ pub fn draw_left_panel(
     tree_window_open: &mut bool,
     branch_limit: &mut u32,
     limit_culling: &mut bool,
+    selected_node_help_open: &mut bool,
 ) {
     egui::SidePanel::left("tree").show(ctx, |side_ui| {
         egui::ScrollArea::vertical().show(side_ui, |ui| {
@@ -204,9 +205,28 @@ pub fn draw_left_panel(
                 if let Some(ref root) = *bsp_root_preview {
                     if let Some(node) = crate::bsp::find_node(root, node_id) {
                         ui.separator();
-                        ui.heading("Vybraný uzel");
+                        ui.horizontal(|ui| {
+                            ui.heading("Vybraný uzel");
+                            if ui.button("❓").on_hover_text("Vysvětlivky").clicked() {
+                                *selected_node_help_open = true;
+                            }
+                        });
                         ui.label(format!("ID: {}", node.id));
                         ui.label(format!("Trojúhelníků: {}", node.subtree_triangles()));
+                        // Additional contextual information about the selected node
+                        // How deep in the tree this node is
+                        let mut path = Vec::new();
+                        let depth = if crate::bsp::find_node_path(root, node.id, &mut path) {
+                            path.len().saturating_sub(1)
+                        } else {
+                            0
+                        };
+                        ui.label(format!("Hloubka: {}", depth));
+                        // How many nodes were visited when this node was picked
+                        ui.label(format!(
+                            "Navštíveno uzlů při výběru: {}",
+                            current_stats.nodes_to_selected
+                        ));
                         if let Some(ref plane) = node.plane {
                             ui.label("Dělící rovina:");
                             ui.label(format!(
@@ -246,10 +266,6 @@ pub fn draw_left_panel(
 
                     ui.label("Navštíveno uzlů");
                     ui.label(format!("{}", current_stats.nodes_visited));
-                    ui.end_row();
-
-                    ui.label("K výběru navštíveno uzlů");
-                    ui.label(format!("{}", current_stats.nodes_to_selected));
                     ui.end_row();
 
                     ui.label("Vykresleno trojúhelníků");
@@ -390,6 +406,19 @@ pub fn draw_left_panel(
             }
         });
     });
+    if *selected_node_help_open {
+        egui::Window::new("Vysvětlivky - Vybraný uzel")
+            .open(selected_node_help_open)
+            .show(ctx, |ui| {
+                ui.label("Tato sekce zobrazuje detaily o aktuálně vybraném uzlu v BSP stromu.");
+                ui.separator();
+                ui.label("• Hloubka udává, kolik hran vede od kořene k tomuto uzlu. Kořen má hloubku 0 a každá úroveň ji zvyšuje o 1.");
+                ui.label("• Navštíveno uzlů při výběru je počet uzlů, které algoritmus prozkoumal, než našel tento uzel. Číslo bývá vyšší než hloubka, protože se kontrolují i jiné větve stromu.");
+                ui.separator();
+                ui.label("Praktický příklad:");
+                ui.label("Uzel na hloubce 3 znamená cestu kořen → A → B → C. Pokud algoritmus při hledání zkontroluje ještě dvě vedlejší větve, může být celkový počet navštívených uzlů 5.");
+            });
+    }
     if *tree_window_open {
         if let Some(ref root) = *bsp_root_preview {
             draw_bsp_tree_window(ctx, tree_window_open, root, selected_node);

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,6 +394,7 @@ fn main() -> Result<()> {
     let mut show_loaded_model = true;
     let mut show_selected_model = true;
     let mut tree_window_open = false;
+    let mut selected_node_help_open = false;
     let mut branch_limit = DEFAULT_BRANCH_LIMIT;
     let mut last_branch_limit = branch_limit;
     let mut limit_culling = false;
@@ -638,6 +639,7 @@ fn main() -> Result<()> {
                     &mut tree_window_open,
                     &mut branch_limit,
                     &mut limit_culling,
+                    &mut selected_node_help_open,
                 );
             },
         );


### PR DESCRIPTION
## Summary
- add question-mark button that opens an explanatory window for the selected BSP node
- describe depth and node visitation stats with a practical example
- track help popup state in the main application

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7efc0f8832fbdd7648bdde8edf0

## Summary by Sourcery

Add a contextual help popup to the selected BSP node panel, offering depth and visitation stats with a practical example, and manage its visibility state in the application.

New Features:
- Add a question-mark button in the selected BSP node panel to open an explanatory popup window.
- Implement a help popup window detailing node depth and nodes-visited statistics with a practical example.
- Introduce a selected_node_help_open state variable in the main application to track the help popup visibility.

Enhancements:
- Move the "nodes to selected" statistic into the selected node detail section of the UI.