### PR TITLE
Parallelize BSP operations and preallocate mesh buffers

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -2,6 +2,7 @@
 // BSP and geometry utilities
 use cgmath::Vector3;
 use rayon::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use three_d::*;
 
 // Configuration values (colors and tree limits)
@@ -293,10 +294,9 @@ pub fn build_bsp(
     triangles: &[Triangle],
     depth: u32,
     max_depth: u32,
-    next_id: &mut usize,
+    next_id: &AtomicUsize,
 ) -> BspNode {
-    let my_id = *next_id;
-    *next_id += 1;
+    let my_id = next_id.fetch_add(1, Ordering::SeqCst);
 
     if depth >= max_depth || triangles.len() <= MIN_TRIANGLES_PER_LEAF {
         return BspNode::new_leaf(triangles.to_vec(), my_id);
@@ -321,9 +321,11 @@ pub fn build_bsp(
         return BspNode::new_leaf(triangles.to_vec(), my_id);
     }
 
-    // Rekurzivní stavba podstromů - use sequential processing to fix ID assignment
-    let front_node = build_bsp(&front_triangles, depth + 1, max_depth, next_id);
-    let back_node = build_bsp(&back_triangles, depth + 1, max_depth, next_id);
+    // Rekurzivní stavba podstromů v paralelních větvích
+    let (front_node, back_node) = rayon::join(
+        || build_bsp(&front_triangles, depth + 1, max_depth, next_id),
+        || build_bsp(&back_triangles, depth + 1, max_depth, next_id),
+    );
 
     BspNode::new_node(splitting_plane, front_node, back_node, my_id)
 }
@@ -582,61 +584,103 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
     };
 
     match &mesh.indices {
-        Indices::U32(indices) => indices
-            .par_chunks(3)
-            .filter_map(|chunk| {
-                if chunk.len() < 3 {
-                    return None;
-                }
-                let a_idx = chunk[0] as usize;
-                let b_idx = chunk[1] as usize;
-                let c_idx = chunk[2] as usize;
+        Indices::U32(indices) => {
+            let tri_count = indices.len() / 3;
+            let mut tris = Vec::with_capacity(tri_count);
+            tris.par_extend(
+                indices.par_chunks(3).filter_map(|chunk| {
+                    if chunk.len() < 3 {
+                        return None;
+                    }
+                    let a_idx = chunk[0] as usize;
+                    let b_idx = chunk[1] as usize;
+                    let c_idx = chunk[2] as usize;
 
-                if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
-                    Some(Triangle {
-                        a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
-                        b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
-                        c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect(),
-        Indices::U16(indices) => indices
-            .par_chunks(3)
-            .filter_map(|chunk| {
-                if chunk.len() < 3 {
-                    return None;
-                }
-                let a_idx = chunk[0] as usize;
-                let b_idx = chunk[1] as usize;
-                let c_idx = chunk[2] as usize;
-
-                if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
-                    Some(Triangle {
-                        a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
-                        b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
-                        c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect(),
-        Indices::None => positions
-            .par_chunks(3)
-            .filter_map(|chunk| {
-                if chunk.len() < 3 {
-                    return None;
-                }
-                Some(Triangle {
-                    a: Vector3::new(chunk[0].x, chunk[0].y, chunk[0].z),
-                    b: Vector3::new(chunk[1].x, chunk[1].y, chunk[1].z),
-                    c: Vector3::new(chunk[2].x, chunk[2].y, chunk[2].z),
+                    if a_idx < positions.len()
+                        && b_idx < positions.len()
+                        && c_idx < positions.len()
+                    {
+                        Some(Triangle {
+                            a: Vector3::new(
+                                positions[a_idx].x,
+                                positions[a_idx].y,
+                                positions[a_idx].z,
+                            ),
+                            b: Vector3::new(
+                                positions[b_idx].x,
+                                positions[b_idx].y,
+                                positions[b_idx].z,
+                            ),
+                            c: Vector3::new(
+                                positions[c_idx].x,
+                                positions[c_idx].y,
+                                positions[c_idx].z,
+                            ),
+                        })
+                    } else {
+                        None
+                    }
                 })
-            })
-            .collect(),
+            );
+            tris
+        }
+        Indices::U16(indices) => {
+            let tri_count = indices.len() / 3;
+            let mut tris = Vec::with_capacity(tri_count);
+            tris.par_extend(
+                indices.par_chunks(3).filter_map(|chunk| {
+                    if chunk.len() < 3 {
+                        return None;
+                    }
+                    let a_idx = chunk[0] as usize;
+                    let b_idx = chunk[1] as usize;
+                    let c_idx = chunk[2] as usize;
+
+                    if a_idx < positions.len()
+                        && b_idx < positions.len()
+                        && c_idx < positions.len()
+                    {
+                        Some(Triangle {
+                            a: Vector3::new(
+                                positions[a_idx].x,
+                                positions[a_idx].y,
+                                positions[a_idx].z,
+                            ),
+                            b: Vector3::new(
+                                positions[b_idx].x,
+                                positions[b_idx].y,
+                                positions[b_idx].z,
+                            ),
+                            c: Vector3::new(
+                                positions[c_idx].x,
+                                positions[c_idx].y,
+                                positions[c_idx].z,
+                            ),
+                        })
+                    } else {
+                        None
+                    }
+                })
+            );
+            tris
+        }
+        Indices::None => {
+            let tri_count = positions.len() / 3;
+            let mut tris = Vec::with_capacity(tri_count);
+            tris.par_extend(
+                positions.par_chunks(3).filter_map(|chunk| {
+                    if chunk.len() < 3 {
+                        return None;
+                    }
+                    Some(Triangle {
+                        a: Vector3::new(chunk[0].x, chunk[0].y, chunk[0].z),
+                        b: Vector3::new(chunk[1].x, chunk[1].y, chunk[1].z),
+                        c: Vector3::new(chunk[2].x, chunk[2].y, chunk[2].z),
+                    })
+                })
+            );
+            tris
+        }
         _ => Vec::new(), // Přidáno pro pokrytí všech případů
     }
 }
@@ -683,43 +727,115 @@ pub fn traverse_bsp_with_frustum(
 
         if side >= 0 {
             // Pozorovatel je před rovinou, nejprve front, pak back
-            if let Some(ref front) = node.front {
-                traverse_bsp_with_frustum(
-                    front,
-                    observer_position,
-                    frustum,
-                    stats,
-                    visible_triangles,
-                );
-            }
-            if let Some(ref back) = node.back {
-                traverse_bsp_with_frustum(
-                    back,
-                    observer_position,
-                    frustum,
-                    stats,
-                    visible_triangles,
-                );
+            match (node.front.as_ref(), node.back.as_ref()) {
+                (Some(front), Some(back)) => {
+                    let (mut front_stats, mut front_tris, mut back_stats, mut back_tris) = (
+                        BspStats::default(),
+                        Vec::new(),
+                        BspStats::default(),
+                        Vec::new(),
+                    );
+                    rayon::join(
+                        || {
+                            traverse_bsp_with_frustum(
+                                front,
+                                observer_position,
+                                frustum,
+                                &mut front_stats,
+                                &mut front_tris,
+                            );
+                        },
+                        || {
+                            traverse_bsp_with_frustum(
+                                back,
+                                observer_position,
+                                frustum,
+                                &mut back_stats,
+                                &mut back_tris,
+                            );
+                        },
+                    );
+                    stats.nodes_visited += front_stats.nodes_visited + back_stats.nodes_visited;
+                    stats.triangles_rendered +=
+                        front_stats.triangles_rendered + back_stats.triangles_rendered;
+                    visible_triangles.extend(front_tris);
+                    visible_triangles.extend(back_tris);
+                }
+                (Some(front), None) => {
+                    traverse_bsp_with_frustum(
+                        front,
+                        observer_position,
+                        frustum,
+                        stats,
+                        visible_triangles,
+                    );
+                }
+                (None, Some(back)) => {
+                    traverse_bsp_with_frustum(
+                        back,
+                        observer_position,
+                        frustum,
+                        stats,
+                        visible_triangles,
+                    );
+                }
+                _ => {}
             }
         } else {
             // Pozorovatel je za rovinou, nejprve back, pak front
-            if let Some(ref back) = node.back {
-                traverse_bsp_with_frustum(
-                    back,
-                    observer_position,
-                    frustum,
-                    stats,
-                    visible_triangles,
-                );
-            }
-            if let Some(ref front) = node.front {
-                traverse_bsp_with_frustum(
-                    front,
-                    observer_position,
-                    frustum,
-                    stats,
-                    visible_triangles,
-                );
+            match (node.back.as_ref(), node.front.as_ref()) {
+                (Some(back), Some(front)) => {
+                    let (mut back_stats, mut back_tris, mut front_stats, mut front_tris) = (
+                        BspStats::default(),
+                        Vec::new(),
+                        BspStats::default(),
+                        Vec::new(),
+                    );
+                    rayon::join(
+                        || {
+                            traverse_bsp_with_frustum(
+                                back,
+                                observer_position,
+                                frustum,
+                                &mut back_stats,
+                                &mut back_tris,
+                            );
+                        },
+                        || {
+                            traverse_bsp_with_frustum(
+                                front,
+                                observer_position,
+                                frustum,
+                                &mut front_stats,
+                                &mut front_tris,
+                            );
+                        },
+                    );
+                    stats.nodes_visited += back_stats.nodes_visited + front_stats.nodes_visited;
+                    stats.triangles_rendered +=
+                        back_stats.triangles_rendered + front_stats.triangles_rendered;
+                    visible_triangles.extend(back_tris);
+                    visible_triangles.extend(front_tris);
+                }
+                (Some(back), None) => {
+                    traverse_bsp_with_frustum(
+                        back,
+                        observer_position,
+                        frustum,
+                        stats,
+                        visible_triangles,
+                    );
+                }
+                (None, Some(front)) => {
+                    traverse_bsp_with_frustum(
+                        front,
+                        observer_position,
+                        frustum,
+                        stats,
+                        visible_triangles,
+                    );
+                }
+                _ => {}
             }
         }
     }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -3,6 +3,7 @@ use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::AtomicUsize;
 
 struct TreePlotData {
     positions: HashMap<usize, PlotPoint>,
@@ -393,12 +394,12 @@ pub fn draw_left_panel(
                         *loaded_file_name = file_name;
                         *file_loading = false;
                         *current_triangles = crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
-                        let mut next_id = 0;
+                        let next_id = AtomicUsize::new(0);
                         *bsp_root_preview = Some(crate::bsp::build_bsp(
                             current_triangles,
                             0,
                             *branch_limit,
-                            &mut next_id,
+                            &next_id,
                         ));
                     }
                     _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use anyhow::Result;
 use cgmath::{Deg, InnerSpace, Vector3};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{atomic::AtomicUsize, mpsc};
 use std::thread;
 use three_d::*; // Add Rayon prelude for parallelization
 
@@ -282,26 +282,29 @@ fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, Co
     // Paralelní zpracování pozic a indexů
     let triangles_count = triangles.len();
 
-    // Paralelně vytvoříme pozice vrcholů
-    let positions: Vec<Vec3> = triangles
-        .par_iter()
-        .flat_map(|tri| {
-            vec![
-                vec3(tri.a.x, tri.a.y, tri.a.z),
-                vec3(tri.b.x, tri.b.y, tri.b.z),
-                vec3(tri.c.x, tri.c.y, tri.c.z),
-            ]
-        })
-        .collect();
+    // Předalokujeme pozice vrcholů a vyplníme je paralelně
+    let mut positions = vec![vec3(0.0, 0.0, 0.0); triangles_count * 3];
+    positions
+        .par_chunks_mut(3)
+        .enumerate()
+        .for_each(|(i, chunk)| {
+            let tri = &triangles[i];
+            chunk[0] = vec3(tri.a.x, tri.a.y, tri.a.z);
+            chunk[1] = vec3(tri.b.x, tri.b.y, tri.b.z);
+            chunk[2] = vec3(tri.c.x, tri.c.y, tri.c.z);
+        });
 
-    // Paralelně vygenerujeme indexy
-    let indices: Vec<u32> = (0..triangles_count as u32)
-        .into_par_iter()
-        .flat_map(|i| {
-            let base_idx = i * 3;
-            vec![base_idx, base_idx + 1, base_idx + 2]
-        })
-        .collect();
+    // Předalokujeme indexy a naplníme je paralelně
+    let mut indices = vec![0u32; triangles_count * 3];
+    indices
+        .par_chunks_mut(3)
+        .enumerate()
+        .for_each(|(i, chunk)| {
+            let base = i as u32 * 3;
+            chunk[0] = base;
+            chunk[1] = base + 1;
+            chunk[2] = base + 2;
+        });
 
     // Vytvoření nového meshe
     let visible_mesh = CpuMesh {
@@ -377,8 +380,8 @@ fn main() -> Result<()> {
     // Spuštění stavby BSP stromu v jiném vlákně
     let branch_limit_clone = MAX_BSP_DEPTH;
     thread::spawn(move || {
-        let mut next_id = 0;
-        let tree = build_bsp(&triangles_clone, 0, branch_limit_clone, &mut next_id);
+        let next_id = AtomicUsize::new(0);
+        let tree = build_bsp(&triangles_clone, 0, branch_limit_clone, &next_id);
         println!("✓ BSP strom sestaven s {} uzly", tree.count_nodes());
         tx.send(Message::InitialTree(tree)).unwrap();
     });
@@ -504,9 +507,9 @@ fn main() -> Result<()> {
                 Message::InitialTree(tree) => {
                     total_stats.total_nodes = tree.count_nodes();
                     bsp_root_full = Some(tree);
-                    let mut next_id = 0;
+                    let next_id = AtomicUsize::new(0);
                     bsp_root_preview =
-                        Some(build_bsp(&current_triangles, 0, branch_limit, &mut next_id));
+                        Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
                     println!("✅ BSP strom úspěšně načten do GUI!");
                 }
                 Message::NewFile {
@@ -520,17 +523,17 @@ fn main() -> Result<()> {
                     loaded_file_name = file_name;
                     file_loading = false;
                     current_triangles = cpu_mesh_to_triangles(&current_cpu_mesh);
-                    let mut next_id = 0;
+                    let next_id = AtomicUsize::new(0);
                     bsp_root_full = Some(build_bsp(
                         &current_triangles,
                         0,
                         MAX_BSP_DEPTH,
-                        &mut next_id,
+                        &next_id,
                     ));
                     total_stats.total_nodes = bsp_root_full.as_ref().unwrap().count_nodes();
-                    let mut next_id = 0;
+                    let next_id = AtomicUsize::new(0);
                     bsp_root_preview =
-                        Some(build_bsp(&current_triangles, 0, branch_limit, &mut next_id));
+                        Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
                     total_stats.total_triangles = current_triangles.len() as u32;
                     println!("✅ Nový model a BSP strom načteny!");
                 }
@@ -645,8 +648,8 @@ fn main() -> Result<()> {
         );
 
         if branch_limit != last_branch_limit {
-            let mut next_id = 0;
-            bsp_root_preview = Some(build_bsp(&current_triangles, 0, branch_limit, &mut next_id));
+            let next_id = AtomicUsize::new(0);
+            bsp_root_preview = Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
             selected_node = None;
             last_branch_limit = branch_limit;
         }


### PR DESCRIPTION
## Summary
- Build BSP subtrees concurrently using `AtomicUsize` IDs
- Traverse BSP branches in parallel during frustum culling
- Preallocate mesh buffers and triangle extraction to avoid repeated allocations

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f2fcc0a4832fbcd83ac558543274

## Summary by Sourcery

Parallelize BSP tree construction, frustum culling, and mesh buffer operations while reducing allocations

Enhancements:
- Use AtomicUsize and rayon::join to build BSP subtrees and traverse branches concurrently
- Preallocate capacity and parallelize triangle extraction in cpu_mesh_to_triangles
- Preallocate and fill vertex and index buffers in create_visible_mesh in parallel