### PR TITLE
Add spectator marker toggle

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -131,7 +131,7 @@ pub fn draw_left_panel(
     disable_culling: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
-    show_camera_direction: &mut bool,
+    show_spectator_marker: &mut bool,
     spectator_state: &mut crate::camera::CameraState,
     third_person_state: &mut crate::camera::CameraState,
     cam: &mut crate::camera::FreeCamera,
@@ -379,7 +379,7 @@ pub fn draw_left_panel(
                 "Vzdálenost mezi kamerami: {:.1}",
                 (spectator_state.pos - third_person_state.pos).magnitude()
             ));
-            ui.checkbox(show_camera_direction, "Zobrazit směr pohledu kamery");
+            ui.checkbox(show_spectator_marker, "Zobrazit pozici a směr spectatoru");
 
             if let Ok(msg) = rx.try_recv() {
                 match msg {

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,8 +463,8 @@ fn main() -> Result<()> {
     let mut third_person_state = CameraState::new(default_third_person_pos); // Jiná pozice pro lepší vizualizaci
     let mut mode = CamMode::Spectator;
 
-    // Proměnná pro sledování, zda zobrazit směr pohledu kamery
-    let mut show_camera_direction = false;
+    // Proměnná pro zobrazení značky spectator kamery
+    let mut show_spectator_marker = false;
 
     // Nastavení pozic glow efektů podle stavů kamer
     spectator_glow.set_transformation(
@@ -524,12 +524,7 @@ fn main() -> Result<()> {
                     file_loading = false;
                     current_triangles = cpu_mesh_to_triangles(&current_cpu_mesh);
                     let next_id = AtomicUsize::new(0);
-                    bsp_root_full = Some(build_bsp(
-                        &current_triangles,
-                        0,
-                        MAX_BSP_DEPTH,
-                        &next_id,
-                    ));
+                    bsp_root_full = Some(build_bsp(&current_triangles, 0, MAX_BSP_DEPTH, &next_id));
                     total_stats.total_nodes = bsp_root_full.as_ref().unwrap().count_nodes();
                     let next_id = AtomicUsize::new(0);
                     bsp_root_preview =
@@ -634,7 +629,7 @@ fn main() -> Result<()> {
                     &mut disable_culling,
                     &mut show_loaded_model,
                     &mut show_selected_model,
-                    &mut show_camera_direction,
+                    &mut show_spectator_marker,
                     &mut spectator_state,
                     &mut third_person_state,
                     &mut cam,
@@ -846,7 +841,7 @@ fn main() -> Result<()> {
             );
 
             // Aktualizuj směrový paprsek pro spectator kameru
-            if show_camera_direction {
+            if show_spectator_marker {
                 // Získáme směrový vektor kamery a nastavíme transformaci paprsku
                 let dir = cam.dir();
 
@@ -910,7 +905,7 @@ fn main() -> Result<()> {
             );
 
             // Když jsme v third person mode, zobrazíme směrový paprsek pro spectator kameru
-            if show_camera_direction {
+            if show_spectator_marker {
                 // Získáme směrový vektor kamery a nastavíme transformaci paprsku
                 // Tentokrát použijeme směr spectator kamery
                 let dir = Vector3::new(
@@ -994,6 +989,10 @@ fn main() -> Result<()> {
         }
         if let Some(ref plane_mesh) = splitting_plane_mesh {
             objects_to_render.push(plane_mesh);
+        }
+        if show_spectator_marker && mode == CamMode::ThirdPerson {
+            objects_to_render.push(&spectator_glow);
+            objects_to_render.push(&camera_direction_ray);
         }
         // ... další objekty ...
         screen.render(


### PR DESCRIPTION
## Summary
- add checkbox to toggle spectator position and direction marker
- render spectator marker with direction arrow when enabled

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a9e770c854832f84e24fe86eaf6455

## Summary by Sourcery

Add a toggle to show spectator position and direction marker and update related rendering and GUI logic

New Features:
- Provide a UI checkbox to enable or disable the spectator position and direction marker

Enhancements:
- Rename show_camera_direction variable to show_spectator_marker for clarity
- Render the spectator marker and direction arrow only when the toggle is enabled and in third-person mode
- Update the GUI label to 'Zobrazit pozici a směr spectatoru' to reflect the new toggle