### PR TITLE
Make camera markers and ambient light configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ The left panel also exposes a checkbox to disable culling and options to view
 the BSP tree.  When a node is selected, its splitting plane and triangles are
 highlighted in the 3D view.
 
+## Configuration
+
+User-tunable parameters are collected in [`src/config.rs`](src/config.rs). Colors
+and lighting can be customized by editing the constants in this file, e.g.:
+
+- `SPECTATOR_GLOW_COLOR` – color of the spectator camera marker.
+- `THIRD_PERSON_GLOW_COLOR` – color of the third person marker.
+- `DIRECTION_RAY_COLOR` – color of the camera direction indicator.
+- `AMBIENT_LIGHT_INTENSITY` and `AMBIENT_LIGHT_COLOR` – ambient light settings.
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,21 @@ pub const HIGHLIGHT_COLOR: Srgba = Srgba::new(255, 50, 50, 150);
 /// Color of the optional splitting plane preview.
 pub const PLANE_COLOR: Srgba = Srgba::new(200, 200, 50, 128);
 
+/// Color used for the spectator camera marker.
+pub const SPECTATOR_GLOW_COLOR: Srgba = Srgba::new(0, 255, 100, 200);
+
+/// Color used for the third person camera marker.
+pub const THIRD_PERSON_GLOW_COLOR: Srgba = Srgba::new(255, 100, 0, 200);
+
+/// Color used for the camera direction indicator.
+pub const DIRECTION_RAY_COLOR: Srgba = Srgba::new(255, 255, 0, 200);
+
+/// Intensity of the ambient light in the scene.
+pub const AMBIENT_LIGHT_INTENSITY: f32 = 1.0;
+
+/// Color of the ambient light in the scene.
+pub const AMBIENT_LIGHT_COLOR: Srgba = Srgba::WHITE;
+
 /// Maximum allowed depth when building the BSP tree.
 pub const MAX_BSP_DEPTH: u32 = 16;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,10 @@ use crate::bsp::{
     triangle_center, BspNode, BspStats, Frustum, Triangle,
 };
 use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
-use crate::config::{BG_COLOR, DEFAULT_BRANCH_LIMIT, MAX_BSP_DEPTH, MODEL_COLOR};
+use crate::config::{
+    AMBIENT_LIGHT_COLOR, AMBIENT_LIGHT_INTENSITY, BG_COLOR, DEFAULT_BRANCH_LIMIT,
+    DIRECTION_RAY_COLOR, MAX_BSP_DEPTH, MODEL_COLOR, SPECTATOR_GLOW_COLOR, THIRD_PERSON_GLOW_COLOR,
+};
 use crate::input::{InputManager, KeyCode};
 
 mod bsp;
@@ -420,7 +423,7 @@ fn main() -> Result<()> {
     let spectator_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(0, 255, 100, 200), // Zelená pro spectator
+            albedo: SPECTATOR_GLOW_COLOR, // Zelená pro spectator
             ..Default::default()
         },
     );
@@ -428,7 +431,7 @@ fn main() -> Result<()> {
     let third_person_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(255, 100, 0, 200), // Oranžová pro third person
+            albedo: THIRD_PERSON_GLOW_COLOR, // Oranžová pro third person
             ..Default::default()
         },
     );
@@ -437,7 +440,7 @@ fn main() -> Result<()> {
     let direction_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(255, 255, 0, 200), // Žlutá barva pro směrový paprsek
+            albedo: DIRECTION_RAY_COLOR, // Žlutá barva pro směrový paprsek
             ..Default::default()
         },
     );
@@ -451,7 +454,7 @@ fn main() -> Result<()> {
     let mut camera_direction_ray =
         Gm::new(Mesh::new(&context, &direction_mesh), direction_material);
 
-    let ambient_light = AmbientLight::new(&context, 1.0, Srgba::WHITE); // Zvýšit intenzitu světla
+    let ambient_light = AmbientLight::new(&context, AMBIENT_LIGHT_INTENSITY, AMBIENT_LIGHT_COLOR); // Zvýšit intenzitu světla
 
     // Nastavení výchozích pozic pro kamery (spawnpoint)
     let default_spectator_pos = Vector3::new(0.0, 2.0, 8.0);


### PR DESCRIPTION
## Summary
- expose constants for camera marker colors and ambient light in `config.rs`
- use the new config values for spectator/third-person markers, direction ray and ambient light
- document how to adjust these values in the README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab30b24b40832f8998d590ca769155

## Summary by Sourcery

Expose configurable constants for camera marker colors and ambient light, apply them in the rendering setup, and document customization options in the README

New Features:
- Add SPECTATOR_GLOW_COLOR, THIRD_PERSON_GLOW_COLOR, DIRECTION_RAY_COLOR, AMBIENT_LIGHT_COLOR, and AMBIENT_LIGHT_INTENSITY constants to config.rs

Enhancements:
- Replace hard-coded spectator, third-person marker colors, direction ray color, and ambient light settings in main.rs with new config constants

Documentation:
- Document how to customize camera marker colors and ambient light parameters in README.md