### PR TITLE
Make camera markers and ambient light configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,24 @@ The left panel also exposes a checkbox to disable culling and options to view
 the BSP tree.  When a node is selected, its splitting plane and triangles are
 highlighted in the 3D view.
 
+## Configuration / Konfigurace
+
+User-tunable parameters are collected in [`src/config.rs`](src/config.rs). Colors
+use `Srgba::new(R, G, B, A)` with 0–255 components and lighting can be adjusted
+by editing the constants in this file.
+
+Uživatelsky nastavitelné parametry jsou soustředěny v [`src/config.rs`](src/config.rs).
+Barvy používají `Srgba::new(R, G, B, A)` s hodnotami 0–255 a společně s osvětlením
+je lze měnit úpravou konstant v tomto souboru.
+
+- `SPECTATOR_GLOW_COLOR` – color of the glowing marker showing the Spectator camera /
+  barva svítící značky kamery v režimu Spectator.
+- `THIRD_PERSON_GLOW_COLOR` – color of the third-person camera marker /
+  barva značky kamery ve třetí osobě.
+- `DIRECTION_RAY_COLOR` – color of the ray visualizing the camera direction /
+  barva paprsku znázorňujícího směr kamery.
+- `AMBIENT_LIGHT_INTENSITY` – how strong the ambient light is /
+  jak silné je ambientní světlo.
+- `AMBIENT_LIGHT_COLOR` – color tint of the ambient light /
+  barva ambientního světla.
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,26 +1,56 @@
 //! Central place for user‑tunable parameters.
 //! Values here can be quickly adjusted without digging
 //! through the rest of the code base.
+//!
+//! Centrální místo pro parametry, které může uživatel snadno měnit
+//! bez nutnosti procházet zbytek kódu.
 
 use three_d::Srgba;
 
 /// Background color of the main render target (RGB 0.0‑1.0).
+/// Barva pozadí hlavního render targetu (RGB 0.0‑1.0).
 pub const BG_COLOR: (f32, f32, f32) = (0.1, 0.1, 0.1);
 
 /// Color used for the loaded model.
+/// Barva nahraného modelu.
 pub const MODEL_COLOR: Srgba = Srgba::new(100, 150, 255, 255);
 
 /// Color used to highlight the currently selected geometry.
+/// Barva zvýraznění aktuálně vybraných trojúhelníků.
 pub const HIGHLIGHT_COLOR: Srgba = Srgba::new(255, 50, 50, 150);
 
 /// Color of the optional splitting plane preview.
+/// Barva náhledové dělicí roviny.
 pub const PLANE_COLOR: Srgba = Srgba::new(200, 200, 50, 128);
 
+/// Color of the glowing marker for the Spectator camera.
+/// Barva svítící značky pro kameru v režimu Spectator.
+pub const SPECTATOR_GLOW_COLOR: Srgba = Srgba::new(0, 255, 100, 200);
+
+/// Color of the marker indicating the third‑person camera.
+/// Barva značky kamery ve třetí osobě.
+pub const THIRD_PERSON_GLOW_COLOR: Srgba = Srgba::new(255, 100, 0, 200);
+
+/// Color of the ray that shows the camera's forward direction.
+/// Barva paprsku znázorňujícího směr kamery.
+pub const DIRECTION_RAY_COLOR: Srgba = Srgba::new(255, 255, 0, 200);
+
+/// Intensity multiplier for ambient light (higher = brighter scene).
+/// Koeficient intenzity ambientního světla (vyšší = světlejší scéna).
+pub const AMBIENT_LIGHT_INTENSITY: f32 = 1.0;
+
+/// Color tint of the ambient light.
+/// Barva (odstín) ambientního světla.
+pub const AMBIENT_LIGHT_COLOR: Srgba = Srgba::WHITE;
+
 /// Maximum allowed depth when building the BSP tree.
+/// Maximální povolená hloubka při stavbě BSP stromu.
 pub const MAX_BSP_DEPTH: u32 = 16;
 
 /// Default depth limit used when initially building the BSP tree.
+/// Výchozí limit hloubky při počáteční stavbě BSP stromu.
 pub const DEFAULT_BRANCH_LIMIT: u32 = 7;
 
 /// Minimum number of triangles inside a leaf before we stop splitting.
+/// Minimální počet trojúhelníků v listu, než přestaneme dělit.
 pub const MIN_TRIANGLES_PER_LEAF: usize = 20;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,10 @@ use crate::bsp::{
     triangle_center, BspNode, BspStats, Frustum, Triangle,
 };
 use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
-use crate::config::{BG_COLOR, DEFAULT_BRANCH_LIMIT, MAX_BSP_DEPTH, MODEL_COLOR};
+use crate::config::{
+    AMBIENT_LIGHT_COLOR, AMBIENT_LIGHT_INTENSITY, BG_COLOR, DEFAULT_BRANCH_LIMIT,
+    DIRECTION_RAY_COLOR, MAX_BSP_DEPTH, MODEL_COLOR, SPECTATOR_GLOW_COLOR, THIRD_PERSON_GLOW_COLOR,
+};
 use crate::input::{InputManager, KeyCode};
 
 mod bsp;
@@ -407,20 +410,22 @@ fn main() -> Result<()> {
     let material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: MODEL_COLOR, // Modrá barva aby byl model viditelný
+            albedo: MODEL_COLOR, // Model color / Barva modelu
             ..Default::default()
         },
     );
     let _model = Gm::new(Mesh::new(&context, &cpu_mesh), material.clone());
 
-    // Glow efekty pro pozice kamer
+    // Mesh used for glowing camera markers
+    // Mesh pro svítící značky kamer
     let glow_mesh = CpuMesh::sphere(16);
 
-    // Materiály pro glow efekty
+    // Materials for the camera markers
+    // Materiály pro značky kamer
     let spectator_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(0, 255, 100, 200), // Zelená pro spectator
+            albedo: SPECTATOR_GLOW_COLOR, // Spectator marker color / Zelená pro spectator
             ..Default::default()
         },
     );
@@ -428,16 +433,17 @@ fn main() -> Result<()> {
     let third_person_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(255, 100, 0, 200), // Oranžová pro third person
+            albedo: THIRD_PERSON_GLOW_COLOR, // Third-person marker color / Oranžová pro third person
             ..Default::default()
         },
     );
 
+    // Material for the camera direction ray
     // Materiál pro směrový paprsek kamery
     let direction_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: Srgba::new(255, 255, 0, 200), // Žlutá barva pro směrový paprsek
+            albedo: DIRECTION_RAY_COLOR, // Color of the direction ray / Žlutá barva pro směrový paprsek
             ..Default::default()
         },
     );
@@ -446,12 +452,15 @@ fn main() -> Result<()> {
     let mut third_person_glow =
         Gm::new(Mesh::new(&context, &glow_mesh), third_person_glow_material);
 
-    // Vytvoření kuželu (cone) pro směrový indikátor kamery místo cylindru
+    // Create a cone mesh for the camera direction indicator
+    // Vytvoření kuželu pro směrový indikátor kamery
     let direction_mesh = CpuMesh::cone(16);
     let mut camera_direction_ray =
         Gm::new(Mesh::new(&context, &direction_mesh), direction_material);
 
-    let ambient_light = AmbientLight::new(&context, 1.0, Srgba::WHITE); // Zvýšit intenzitu světla
+    // Ambient light that brightens the whole scene
+    // Ambientní světlo, které prosvětlí celou scénu
+    let ambient_light = AmbientLight::new(&context, AMBIENT_LIGHT_INTENSITY, AMBIENT_LIGHT_COLOR);
 
     // Nastavení výchozích pozic pro kamery (spawnpoint)
     let default_spectator_pos = Vector3::new(0.0, 2.0, 8.0);


### PR DESCRIPTION
## Summary
- expose constants for camera marker colors and ambient light in `config.rs`
- use the new config values for spectator/third-person markers, direction ray and ambient light
- document how to adjust these values in the README, including Czech descriptions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab30b24b40832f8998d590ca769155

## Summary by Sourcery

Expose new configuration constants for camera marker colors and ambient light, update the application to use them, and add bilingual documentation in the README

New Features:
- Add SPECTATOR_GLOW_COLOR, THIRD_PERSON_GLOW_COLOR, DIRECTION_RAY_COLOR, AMBIENT_LIGHT_INTENSITY, and AMBIENT_LIGHT_COLOR constants in config.rs
- Document the new configuration options in README with bilingual (English/Czech) descriptions

Enhancements:
- Replace hard-coded camera marker colors, direction ray color, and ambient light parameters in main.rs with configurable constants