### PR TITLE
Expose adjustable BSP tree label size and colors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 //! through the rest of the code base.
 
 use cgmath::Vector3;
+use egui::Color32;
 use three_d::Srgba;
 
 // -----------------------------------------------------------------------------
@@ -44,6 +45,22 @@ pub const AMBIENT_LIGHT_INTENSITY: f32 = 1.0;
 /// Color of the ambient light in the scene.
 /// Barva ambientního světla ve scéně.
 pub const AMBIENT_LIGHT_COLOR: Srgba = Srgba::WHITE;
+
+// -----------------------------------------------------------------------------
+// BSP tree visualization
+// -----------------------------------------------------------------------------
+
+/// Text size for BSP tree node labels in pixels.
+/// Velikost textu popisků uzlů BSP stromu v pixelech.
+pub const BSP_TREE_TEXT_SIZE: f32 = 16.0;
+
+/// Color used to highlight the path from root to the selected node.
+/// Barva použitá pro zvýraznění cesty od kořene k vybranému uzlu.
+pub const BSP_TREE_PATH_COLOR: Color32 = Color32::from_rgb(255, 200, 0);
+
+/// Color of the selected node in the BSP tree.
+/// Barva vybraného uzlu v BSP stromu.
+pub const BSP_TREE_SELECTED_COLOR: Color32 = Color32::YELLOW;
 
 // -----------------------------------------------------------------------------
 // BSP tree limits

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,6 @@
-use crate::config::MAX_BSP_DEPTH;
+use crate::config::{
+    BSP_TREE_PATH_COLOR, BSP_TREE_SELECTED_COLOR, BSP_TREE_TEXT_SIZE, MAX_BSP_DEPTH,
+};
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
@@ -62,7 +64,8 @@ fn draw_bsp_tree_window(
                 }
             }
 
-            let highlight_color = egui::Color32::from_rgb(255, 200, 0);
+            let highlight_color = BSP_TREE_PATH_COLOR;
+            let selected_color = BSP_TREE_SELECTED_COLOR;
 
             let plot = Plot::new("bsp_tree_plot");
             let plot_resp = plot.show(ui, |plot_ui| {
@@ -80,7 +83,7 @@ fn draw_bsp_tree_window(
                 }
                 for (&id, &pos) in &data.positions {
                     let color = if selected == &Some(id) {
-                        egui::Color32::YELLOW
+                        selected_color
                     } else if path_ids.contains(&id) {
                         highlight_color
                     } else {
@@ -89,7 +92,11 @@ fn draw_bsp_tree_window(
                     let pt = vec![[pos.x, pos.y]];
                     plot_ui.points(Points::new(pt).radius(4.0).color(color));
                     plot_ui.text(
-                        Text::new(pos, format!("{}", id)).anchor(egui::Align2::CENTER_CENTER),
+                        Text::new(
+                            pos,
+                            egui::RichText::new(format!("{}", id)).size(BSP_TREE_TEXT_SIZE),
+                        )
+                        .anchor(egui::Align2::CENTER_CENTER),
                     );
                 }
                 plot_ui.pointer_coordinate()


### PR DESCRIPTION
## Summary
- allow configuring BSP tree label text size and highlight colors via new constants
- render tree labels with larger font size and configurable path/selected colors

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5292eaac832fbf96f9dd3f13161e

## Summary by Sourcery

Expose adjustable label text size and highlight colors for the BSP tree visualization and update the GUI to use these new configuration constants

New Features:
- Add BSP_TREE_TEXT_SIZE constant to configure node label font size
- Add BSP_TREE_PATH_COLOR constant to configure path highlight color
- Add BSP_TREE_SELECTED_COLOR constant to configure selected node color

Enhancements:
- Replace hardcoded colors and text size in BSP tree rendering with the new configurable constants