### PR TITLE
Streamline color settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ highlighted in the 3D view.
 User-tunable parameters are collected in [`src/config.rs`](src/config.rs). Colors
 and lighting can be customized by editing the constants in this file, e.g.:
 
-- `SPECTATOR_GLOW_COLOR` – color of the spectator camera marker.
-- `THIRD_PERSON_GLOW_COLOR` – color of the third person marker.
-- `DIRECTION_RAY_COLOR` – color of the camera direction indicator.
+- `HIGHLIGHT_COLOR` – accent color used for selections, camera markers and the
+  direction indicator.
 - `AMBIENT_LIGHT_INTENSITY` and `AMBIENT_LIGHT_COLOR` – ambient light settings.
+- `DEFAULT_FOV_DEG` – default field of view for the camera.
 

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -566,7 +566,7 @@ pub fn create_plane_mesh(
         ..Default::default()
     };
 
-    let plane_color = CONFIG.lock().unwrap().plane_color;
+    let plane_color = CONFIG.lock().unwrap().highlight_color;
     let material = ColorMaterial::new_transparent(
         context,
         &CpuMaterial {
@@ -590,98 +590,62 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
         Indices::U32(indices) => {
             let tri_count = indices.len() / 3;
             let mut tris = Vec::with_capacity(tri_count);
-            tris.par_extend(
-                indices.par_chunks(3).filter_map(|chunk| {
-                    if chunk.len() < 3 {
-                        return None;
-                    }
-                    let a_idx = chunk[0] as usize;
-                    let b_idx = chunk[1] as usize;
-                    let c_idx = chunk[2] as usize;
+            tris.par_extend(indices.par_chunks(3).filter_map(|chunk| {
+                if chunk.len() < 3 {
+                    return None;
+                }
+                let a_idx = chunk[0] as usize;
+                let b_idx = chunk[1] as usize;
+                let c_idx = chunk[2] as usize;
 
-                    if a_idx < positions.len()
-                        && b_idx < positions.len()
-                        && c_idx < positions.len()
-                    {
-                        Some(Triangle {
-                            a: Vector3::new(
-                                positions[a_idx].x,
-                                positions[a_idx].y,
-                                positions[a_idx].z,
-                            ),
-                            b: Vector3::new(
-                                positions[b_idx].x,
-                                positions[b_idx].y,
-                                positions[b_idx].z,
-                            ),
-                            c: Vector3::new(
-                                positions[c_idx].x,
-                                positions[c_idx].y,
-                                positions[c_idx].z,
-                            ),
-                        })
-                    } else {
-                        None
-                    }
-                })
-            );
+                if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
+                    Some(Triangle {
+                        a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
+                        b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
+                        c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
+                    })
+                } else {
+                    None
+                }
+            }));
             tris
         }
         Indices::U16(indices) => {
             let tri_count = indices.len() / 3;
             let mut tris = Vec::with_capacity(tri_count);
-            tris.par_extend(
-                indices.par_chunks(3).filter_map(|chunk| {
-                    if chunk.len() < 3 {
-                        return None;
-                    }
-                    let a_idx = chunk[0] as usize;
-                    let b_idx = chunk[1] as usize;
-                    let c_idx = chunk[2] as usize;
+            tris.par_extend(indices.par_chunks(3).filter_map(|chunk| {
+                if chunk.len() < 3 {
+                    return None;
+                }
+                let a_idx = chunk[0] as usize;
+                let b_idx = chunk[1] as usize;
+                let c_idx = chunk[2] as usize;
 
-                    if a_idx < positions.len()
-                        && b_idx < positions.len()
-                        && c_idx < positions.len()
-                    {
-                        Some(Triangle {
-                            a: Vector3::new(
-                                positions[a_idx].x,
-                                positions[a_idx].y,
-                                positions[a_idx].z,
-                            ),
-                            b: Vector3::new(
-                                positions[b_idx].x,
-                                positions[b_idx].y,
-                                positions[b_idx].z,
-                            ),
-                            c: Vector3::new(
-                                positions[c_idx].x,
-                                positions[c_idx].y,
-                                positions[c_idx].z,
-                            ),
-                        })
-                    } else {
-                        None
-                    }
-                })
-            );
+                if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
+                    Some(Triangle {
+                        a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
+                        b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
+                        c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
+                    })
+                } else {
+                    None
+                }
+            }));
             tris
         }
         Indices::None => {
             let tri_count = positions.len() / 3;
             let mut tris = Vec::with_capacity(tri_count);
-            tris.par_extend(
-                positions.par_chunks(3).filter_map(|chunk| {
-                    if chunk.len() < 3 {
-                        return None;
-                    }
-                    Some(Triangle {
-                        a: Vector3::new(chunk[0].x, chunk[0].y, chunk[0].z),
-                        b: Vector3::new(chunk[1].x, chunk[1].y, chunk[1].z),
-                        c: Vector3::new(chunk[2].x, chunk[2].y, chunk[2].z),
-                    })
+            tris.par_extend(positions.par_chunks(3).filter_map(|chunk| {
+                if chunk.len() < 3 {
+                    return None;
+                }
+                Some(Triangle {
+                    a: Vector3::new(chunk[0].x, chunk[0].y, chunk[0].z),
+                    b: Vector3::new(chunk[1].x, chunk[1].y, chunk[1].z),
+                    c: Vector3::new(chunk[2].x, chunk[2].y, chunk[2].z),
                 })
-            );
+            }));
             tris
         }
         _ => Vec::new(), // Přidáno pro pokrytí všech případů

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,10 +16,6 @@ pub struct Config {
     pub bg_color: [f32; 3],
     pub model_color: Srgba,
     pub highlight_color: Srgba,
-    pub plane_color: Srgba,
-    pub spectator_glow_color: Srgba,
-    pub third_person_glow_color: Srgba,
-    pub direction_ray_color: Srgba,
     pub ambient_light_intensity: f32,
     pub ambient_light_color: Srgba,
 
@@ -61,10 +57,6 @@ impl Default for Config {
             bg_color: [0.1, 0.1, 0.1],
             model_color: Srgba::new(100, 150, 255, 255),
             highlight_color: Srgba::new(255, 50, 50, 150),
-            plane_color: Srgba::new(200, 200, 50, 128),
-            spectator_glow_color: Srgba::new(0, 255, 100, 200),
-            third_person_glow_color: Srgba::new(255, 100, 0, 200),
-            direction_ray_color: Srgba::new(255, 255, 0, 200),
             ambient_light_intensity: 1.0,
             ambient_light_color: Srgba::WHITE,
             bsp_tree_text_size: 16.0,
@@ -92,4 +84,3 @@ impl Default for Config {
 
 /// Global mutable configuration accessible across modules.
 pub static CONFIG: Lazy<Mutex<Config>> = Lazy::new(|| Mutex::new(Config::default()));
-

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -2,9 +2,9 @@ use crate::config::CONFIG;
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
-use three_d::Srgba;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicUsize;
+use three_d::Srgba;
 
 struct TreePlotData {
     positions: HashMap<usize, PlotPoint>,
@@ -483,61 +483,6 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
                 }
             });
 
-            let mut pcol = egui::Color32::from_rgba_unmultiplied(
-                cfg.plane_color.r,
-                cfg.plane_color.g,
-                cfg.plane_color.b,
-                cfg.plane_color.a,
-            );
-            ui.horizontal(|ui| {
-                ui.label("Plane");
-                if ui.color_edit_button_srgba(&mut pcol).changed() {
-                    cfg.plane_color = Srgba::new(pcol.r(), pcol.g(), pcol.b(), pcol.a());
-                }
-            });
-
-            let mut scol = egui::Color32::from_rgba_unmultiplied(
-                cfg.spectator_glow_color.r,
-                cfg.spectator_glow_color.g,
-                cfg.spectator_glow_color.b,
-                cfg.spectator_glow_color.a,
-            );
-            ui.horizontal(|ui| {
-                ui.label("Spectator glow");
-                if ui.color_edit_button_srgba(&mut scol).changed() {
-                    cfg.spectator_glow_color =
-                        Srgba::new(scol.r(), scol.g(), scol.b(), scol.a());
-                }
-            });
-
-            let mut tcol = egui::Color32::from_rgba_unmultiplied(
-                cfg.third_person_glow_color.r,
-                cfg.third_person_glow_color.g,
-                cfg.third_person_glow_color.b,
-                cfg.third_person_glow_color.a,
-            );
-            ui.horizontal(|ui| {
-                ui.label("Third person glow");
-                if ui.color_edit_button_srgba(&mut tcol).changed() {
-                    cfg.third_person_glow_color =
-                        Srgba::new(tcol.r(), tcol.g(), tcol.b(), tcol.a());
-                }
-            });
-
-            let mut dcol = egui::Color32::from_rgba_unmultiplied(
-                cfg.direction_ray_color.r,
-                cfg.direction_ray_color.g,
-                cfg.direction_ray_color.b,
-                cfg.direction_ray_color.a,
-            );
-            ui.horizontal(|ui| {
-                ui.label("Direction ray");
-                if ui.color_edit_button_srgba(&mut dcol).changed() {
-                    cfg.direction_ray_color =
-                        Srgba::new(dcol.r(), dcol.g(), dcol.b(), dcol.a());
-                }
-            });
-
             ui.add(
                 egui::Slider::new(&mut cfg.ambient_light_intensity, 0.0..=5.0)
                     .text("Ambient intensity"),
@@ -551,17 +496,13 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
             ui.horizontal(|ui| {
                 ui.label("Ambient color");
                 if ui.color_edit_button_srgba(&mut acol).changed() {
-                    cfg.ambient_light_color =
-                        Srgba::new(acol.r(), acol.g(), acol.b(), acol.a());
+                    cfg.ambient_light_color = Srgba::new(acol.r(), acol.g(), acol.b(), acol.a());
                 }
             });
 
             ui.separator();
             ui.heading("BSP Tree");
-            ui.add(
-                egui::Slider::new(&mut cfg.bsp_tree_text_size, 8.0..=32.0)
-                    .text("Text size"),
-            );
+            ui.add(egui::Slider::new(&mut cfg.bsp_tree_text_size, 8.0..=32.0).text("Text size"));
             ui.horizontal(|ui| {
                 ui.label("Path color");
                 ui.color_edit_button_srgba(&mut cfg.bsp_tree_path_color);
@@ -573,9 +514,7 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
 
             ui.separator();
             ui.heading("BSP Limits");
-            ui.add(
-                egui::Slider::new(&mut cfg.max_bsp_depth, 1..=64).text("Max depth"),
-            );
+            ui.add(egui::Slider::new(&mut cfg.max_bsp_depth, 1..=64).text("Max depth"));
             let max_depth = cfg.max_bsp_depth;
             ui.add(
                 egui::Slider::new(&mut cfg.default_branch_limit, 1..=max_depth)
@@ -589,26 +528,13 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
             ui.separator();
             ui.heading("Camera");
             ui.add(
-                egui::Slider::new(&mut cfg.default_camera_speed, 0.1..=20.0)
-                    .text("Default speed"),
+                egui::Slider::new(&mut cfg.default_camera_speed, 0.1..=20.0).text("Default speed"),
             );
-            ui.add(
-                egui::Slider::new(&mut cfg.default_look_speed, 0.1..=10.0)
-                    .text("Look speed"),
-            );
-            ui.add(
-                egui::Slider::new(&mut cfg.pitch_limit, 0.1..=3.14).text("Pitch limit"),
-            );
-            ui.add(
-                egui::Slider::new(&mut cfg.default_fov_deg, 30.0..=120.0)
-                    .text("FOV deg"),
-            );
-            ui.add(
-                egui::Slider::new(&mut cfg.near_plane, 0.01..=1.0).text("Near plane"),
-            );
-            ui.add(
-                egui::Slider::new(&mut cfg.far_plane, 10.0..=5000.0).text("Far plane"),
-            );
+            ui.add(egui::Slider::new(&mut cfg.default_look_speed, 0.1..=10.0).text("Look speed"));
+            ui.add(egui::Slider::new(&mut cfg.pitch_limit, 0.1..=3.14).text("Pitch limit"));
+            ui.add(egui::Slider::new(&mut cfg.default_fov_deg, 30.0..=120.0).text("FOV deg"));
+            ui.add(egui::Slider::new(&mut cfg.near_plane, 0.01..=1.0).text("Near plane"));
+            ui.add(egui::Slider::new(&mut cfg.far_plane, 10.0..=5000.0).text("Far plane"));
             ui.add(
                 egui::Slider::new(&mut cfg.camera_switch_cooldown, 0.1..=10.0)
                     .text("Switch cooldown"),
@@ -631,16 +557,12 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
                 ui.add(egui::DragValue::new(&mut cfg.default_third_person_pos.z));
             });
             ui.add(
-                egui::Slider::new(&mut cfg.camera_marker_scale, 0.01..=1.0)
-                    .text("Marker scale"),
+                egui::Slider::new(&mut cfg.camera_marker_scale, 0.01..=1.0).text("Marker scale"),
             );
             ui.add(
                 egui::Slider::new(&mut cfg.direction_ray_thickness, 0.01..=1.0)
                     .text("Ray thickness"),
             );
-            ui.add(
-                egui::Slider::new(&mut cfg.direction_ray_length, 0.1..=10.0)
-                    .text("Ray length"),
-            );
+            ui.add(egui::Slider::new(&mut cfg.direction_ray_length, 0.1..=10.0).text("Ray length"));
         });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,7 +424,7 @@ fn main() -> Result<()> {
     let spectator_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: cfg.spectator_glow_color,
+            albedo: cfg.highlight_color,
             ..Default::default()
         },
     );
@@ -432,7 +432,7 @@ fn main() -> Result<()> {
     let third_person_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: cfg.third_person_glow_color,
+            albedo: cfg.highlight_color,
             ..Default::default()
         },
     );
@@ -441,7 +441,7 @@ fn main() -> Result<()> {
     let direction_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: cfg.direction_ray_color,
+            albedo: cfg.highlight_color,
             ..Default::default()
         },
     );
@@ -510,9 +510,9 @@ fn main() -> Result<()> {
         // Apply dynamic configuration updates
         ambient_light.intensity = cfg.ambient_light_intensity;
         ambient_light.color = cfg.ambient_light_color;
-        spectator_glow.material.color = cfg.spectator_glow_color;
-        third_person_glow.material.color = cfg.third_person_glow_color;
-        camera_direction_ray.material.color = cfg.direction_ray_color;
+        spectator_glow.material.color = cfg.highlight_color;
+        third_person_glow.material.color = cfg.highlight_color;
+        camera_direction_ray.material.color = cfg.highlight_color;
 
         // Zkontroluj, zda background thread dokončil stavbu BSP stromu
         if let Ok(message) = rx.try_recv() {


### PR DESCRIPTION
## Summary
- consolidate multiple color options into a single `highlight_color`
- simplify configuration window and docs to match streamlined options
- update camera markers and direction ray to use the shared highlight color

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6e67f998832f8a8ba3fa7a90e0ae

## Summary by Sourcery

Streamline color configuration by introducing a single highlight_color setting and removing redundant individual color options, update UI and rendering to use the shared accent color, clean up related config fields and default values, simplify mesh triangle conversion loops, and refresh the documentation to reflect the consolidated color setting.

New Features:
- Add highlight_color config option to unify accent color across planes, camera markers, and direction indicators.

Enhancements:
- Replace plane_color, spectator_glow_color, third_person_glow_color, and direction_ray_color with highlight_color in rendering and dynamic updates.
- Simplify the configuration UI by removing separate color pickers and consolidating into a single highlight_color control.
- Refactor mesh-to-triangle conversion code to streamline par_extend filter_map closures.

Documentation:
- Update README to document highlight_color and remove outdated individual color option references.

Chores:
- Remove deprecated color fields and their default values from the Config struct.