### PR TITLE
Add texture loading and toggling

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -48,7 +48,7 @@ source code so you can jump directly to the implementation.
   tilt from arrow keys.
 
 ## `src/main.rs`
-- [`load_cpu_mesh`](src/main.rs#L65-L110) – load a GLTF/GLB file into a CPU
-  mesh with basic validation.
-- [`load_gltf_with_gltf_crate`](src/main.rs#L112-L162) – helper using the `gltf`
-  crate to parse meshes.
+- [`load_cpu_mesh`](src/main.rs#L61-L109) – load a GLTF/GLB file into a CPU
+  mesh and optional texture with basic validation.
+- [`load_gltf_with_gltf_crate`](src/main.rs#L111-L168) – helper using the
+  `gltf` crate to parse meshes and textures.

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // BSP and geometry utilities
-use cgmath::Vector3;
+use cgmath::{Vector2, Vector3};
 use rayon::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use three_d::*;
@@ -15,6 +15,9 @@ pub struct Triangle {
     pub a: Vector3<f32>,
     pub b: Vector3<f32>,
     pub c: Vector3<f32>,
+    pub uv_a: Vector2<f32>,
+    pub uv_b: Vector2<f32>,
+    pub uv_c: Vector2<f32>,
 }
 
 #[derive(Clone, Debug)]
@@ -585,6 +588,7 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
         Positions::F32(pos) => pos,
         _ => return Vec::new(), // Pokud nemáme F32 pozice, vrátíme prázdný vektor
     };
+    let uvs = mesh.uvs.as_ref();
 
     match &mesh.indices {
         Indices::U32(indices) => {
@@ -599,10 +603,14 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
                 let c_idx = chunk[2] as usize;
 
                 if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
+                    let default_uv = Vector2::new(0.0, 0.0);
                     Some(Triangle {
                         a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
                         b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
                         c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
+                        uv_a: uvs.map_or(default_uv, |u| u[a_idx]),
+                        uv_b: uvs.map_or(default_uv, |u| u[b_idx]),
+                        uv_c: uvs.map_or(default_uv, |u| u[c_idx]),
                     })
                 } else {
                     None
@@ -622,10 +630,14 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
                 let c_idx = chunk[2] as usize;
 
                 if a_idx < positions.len() && b_idx < positions.len() && c_idx < positions.len() {
+                    let default_uv = Vector2::new(0.0, 0.0);
                     Some(Triangle {
                         a: Vector3::new(positions[a_idx].x, positions[a_idx].y, positions[a_idx].z),
                         b: Vector3::new(positions[b_idx].x, positions[b_idx].y, positions[b_idx].z),
                         c: Vector3::new(positions[c_idx].x, positions[c_idx].y, positions[c_idx].z),
+                        uv_a: uvs.map_or(default_uv, |u| u[a_idx]),
+                        uv_b: uvs.map_or(default_uv, |u| u[b_idx]),
+                        uv_c: uvs.map_or(default_uv, |u| u[c_idx]),
                     })
                 } else {
                     None
@@ -636,14 +648,19 @@ pub fn cpu_mesh_to_triangles(mesh: &CpuMesh) -> Vec<Triangle> {
         Indices::None => {
             let tri_count = positions.len() / 3;
             let mut tris = Vec::with_capacity(tri_count);
-            tris.par_extend(positions.par_chunks(3).filter_map(|chunk| {
+            let default_uv = Vector2::new(0.0, 0.0);
+            tris.par_extend(positions.par_chunks(3).enumerate().filter_map(|(i, chunk)| {
                 if chunk.len() < 3 {
                     return None;
                 }
+                let base = i * 3;
                 Some(Triangle {
                     a: Vector3::new(chunk[0].x, chunk[0].y, chunk[0].z),
                     b: Vector3::new(chunk[1].x, chunk[1].y, chunk[1].z),
                     c: Vector3::new(chunk[2].x, chunk[2].y, chunk[2].z),
+                    uv_a: uvs.map_or(default_uv, |u| u[base]),
+                    uv_b: uvs.map_or(default_uv, |u| u[base + 1]),
+                    uv_c: uvs.map_or(default_uv, |u| u[base + 2]),
                 })
             }));
             tris
@@ -1148,12 +1165,18 @@ mod tests {
             a: Vector3::new(1.0, 0.0, 0.0),
             b: Vector3::new(1.0, 1.0, 0.0),
             c: Vector3::new(1.0, 0.0, 1.0),
+            uv_a: Vector2::new(0.0, 0.0),
+            uv_b: Vector2::new(0.0, 0.0),
+            uv_c: Vector2::new(0.0, 0.0),
         };
 
         let outside = Triangle {
             a: Vector3::new(-10.0, 0.0, 0.0),
             b: Vector3::new(-10.0, 1.0, 0.0),
             c: Vector3::new(-10.0, 0.0, 1.0),
+            uv_a: Vector2::new(0.0, 0.0),
+            uv_b: Vector2::new(0.0, 0.0),
+            uv_c: Vector2::new(0.0, 0.0),
         };
 
         let front = BspNode::new_leaf(vec![inside.clone()], 2);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -4,7 +4,7 @@ use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicUsize;
-use three_d::Srgba;
+use three_d::{Srgba, Texture2DRef, CpuTexture};
 
 struct TreePlotData {
     positions: HashMap<usize, PlotPoint>,
@@ -125,6 +125,7 @@ fn draw_bsp_tree_window(
 
 pub fn draw_left_panel(
     ctx: &egui::Context,
+    gl: &three_d::Context,
     mode: crate::camera::CamMode,
     loaded_file_name: &mut String,
     file_loading: &mut bool,
@@ -132,12 +133,14 @@ pub fn draw_left_panel(
     rx: &std::sync::mpsc::Receiver<crate::Message>,
     current_cpu_mesh: &mut three_d::CpuMesh,
     current_triangles: &mut Vec<crate::bsp::Triangle>,
+    current_texture: &mut Option<Texture2DRef>,
     bsp_root_preview: &mut Option<crate::bsp::BspNode>,
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
     disable_culling: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
+    show_texture: &mut bool,
     show_spectator_marker: &mut bool,
     spectator_state: &mut crate::camera::CameraState,
     third_person_state: &mut crate::camera::CameraState,
@@ -172,9 +175,11 @@ pub fn draw_left_panel(
                     let file_name_clone = path.file_name().unwrap().to_string_lossy().into_owned();
                     let tx_gui_clone = tx_gui.clone();
                     std::thread::spawn(move || {
-                        let (new_cpu_mesh, load_status) = crate::load_cpu_mesh(&path_clone);
+                        let (new_cpu_mesh, new_texture, load_status) =
+                            crate::load_cpu_mesh(&path_clone);
                         let _ = tx_gui_clone.send(crate::Message::NewFile {
                             cpu_mesh: new_cpu_mesh,
+                            texture: new_texture,
                             file_name: file_name_clone,
                             load_status,
                             triangles: Vec::new(),
@@ -183,6 +188,21 @@ pub fn draw_left_panel(
                     });
                 }
             }
+            if ui.button("📷 Načíst texturu").clicked() {
+                if let Some(path) = rfd::FileDialog::new()
+                    .add_filter("Image", &["png", "jpg", "jpeg"])
+                    .pick_file()
+                {
+                    if let Ok(tex) =
+                        three_d_asset::io::load_and_deserialize::<CpuTexture>(&path)
+                    {
+                        *current_texture =
+                            Some(Texture2DRef::from_cpu_texture(gl, &tex));
+                        *show_texture = true;
+                    }
+                }
+            }
+            ui.checkbox(show_texture, "Zobrazit texturu");
 
             if *file_loading {
                 ui.add(
@@ -397,6 +417,7 @@ pub fn draw_left_panel(
                 match msg {
                     crate::Message::NewFile {
                         cpu_mesh,
+                        texture,
                         file_name,
                         load_status: _,
                         triangles: _,
@@ -405,7 +426,13 @@ pub fn draw_left_panel(
                         *current_cpu_mesh = cpu_mesh;
                         *loaded_file_name = file_name;
                         *file_loading = false;
-                        *current_triangles = crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
+                        *current_triangles =
+                            crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
+                        *current_texture =
+                            texture.map(|t| Texture2DRef::from_cpu_texture(gl, &t));
+                        if current_texture.is_some() {
+                            *show_texture = true;
+                        }
                         let next_id = AtomicUsize::new(0);
                         *bsp_root_preview = Some(crate::bsp::build_bsp(
                             current_triangles,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ enum Message {
     InitialTree(BspNode),
     NewFile {
         cpu_mesh: CpuMesh,
+        texture: Option<CpuTexture>,
         triangles: Vec<Triangle>,
         file_name: String,
         load_status: String,
@@ -57,13 +58,14 @@ enum Message {
 }
 
 // helper: načte CpuMesh z .glb/.gltf pomocí gltf crate
-fn load_cpu_mesh(path: &Path) -> (CpuMesh, String) {
+fn load_cpu_mesh(path: &Path) -> (CpuMesh, Option<CpuTexture>, String) {
     println!("Pokouším se načíst: {}", path.display());
 
     if !path.exists() {
         println!("Soubor neexistuje: {}", path.display());
         return (
             CpuMesh::sphere(32),
+            None,
             format!("Soubor neexistuje: {}", path.display()),
         );
     }
@@ -72,42 +74,44 @@ fn load_cpu_mesh(path: &Path) -> (CpuMesh, String) {
         Ok(metadata) => {
             println!("Velikost souboru: {} bytes", metadata.len());
             if metadata.len() == 0 {
-                return (CpuMesh::sphere(32), "Soubor je prázdný".to_string());
+                return (CpuMesh::sphere(32), None, "Soubor je prázdný".to_string());
             }
             if metadata.len() > 100_000_000 {
                 // 100MB limit
                 return (
                     CpuMesh::sphere(32),
+                    None,
                     "Soubor je příliš velký (>100MB)".to_string(),
                 );
             }
         }
         Err(e) => {
             println!("Nelze přečíst metadata souboru: {}", e);
-            return (CpuMesh::sphere(32), format!("Chyba metadata: {}", e));
+            return (CpuMesh::sphere(32), None, format!("Chyba metadata: {}", e));
         }
     }
 
     // Pokus načtení pomocí gltf crate
     match load_gltf_with_gltf_crate(path) {
-        Ok(mesh) => {
+        Ok((mesh, texture)) => {
             println!("✓ GLTF úspěšně načten pomocí gltf crate");
-            return (mesh, "GLTF soubor úspěšně načten".to_string());
+            return (mesh, texture, "GLTF soubor úspěšně načten".to_string());
         }
         Err(e) => {
             println!("Chyba při načítání pomocí gltf crate: {}", e);
             return (
                 CpuMesh::sphere(32),
+                None,
                 format!("Nepodařilo se načíst GLTF: {}", e),
             );
         }
     }
 }
 
-fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
+fn load_gltf_with_gltf_crate(path: &Path) -> Result<(CpuMesh, Option<CpuTexture>)> {
     println!("Načítám GLTF pomocí gltf crate...");
 
-    let (document, buffers, _images) = gltf::import(path)?;
+    let (document, buffers, images) = gltf::import(path)?;
 
     println!("GLTF dokument načten:");
     println!("- Scény: {}", document.scenes().count());
@@ -117,7 +121,9 @@ fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
 
     let mut all_positions = Vec::new();
     let mut all_indices = Vec::new();
+    let mut all_uvs = Vec::new();
     let mut vertex_offset = 0u32;
+    let mut texture: Option<CpuTexture> = None;
 
     // Projdi všechny meshe ve scéně
     for scene in document.scenes() {
@@ -127,9 +133,12 @@ fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
             process_node(
                 &node,
                 &buffers,
+                &images,
                 &mut all_positions,
                 &mut all_indices,
+                &mut all_uvs,
                 &mut vertex_offset,
+                &mut texture,
                 cgmath::Matrix4::identity(),
             )?;
         }
@@ -145,23 +154,28 @@ fn load_gltf_with_gltf_crate(path: &Path) -> Result<CpuMesh> {
         all_indices.len()
     );
 
-    Ok(CpuMesh {
+    let mesh = CpuMesh {
         positions: Positions::F32(all_positions),
         indices: if all_indices.is_empty() {
             Indices::None
         } else {
             Indices::U32(all_indices)
         },
+        uvs: if all_uvs.is_empty() { None } else { Some(all_uvs) },
         ..Default::default()
-    })
+    };
+    Ok((mesh, texture))
 }
 
 fn process_node(
     node: &gltf::Node,
     buffers: &[gltf::buffer::Data],
+    images: &[gltf::image::Data],
     all_positions: &mut Vec<Vec3>,
     all_indices: &mut Vec<u32>,
+    all_uvs: &mut Vec<Vec2>,
     vertex_offset: &mut u32,
+    texture: &mut Option<CpuTexture>,
     parent_transform: cgmath::Matrix4<f32>,
 ) -> Result<()> {
     // Získej transformaci uzlu
@@ -182,9 +196,12 @@ fn process_node(
             process_primitive(
                 &primitive,
                 buffers,
+                images,
                 all_positions,
                 all_indices,
+                all_uvs,
                 vertex_offset,
+                texture,
                 current_transform,
             )?;
         }
@@ -195,9 +212,12 @@ fn process_node(
         process_node(
             &child,
             buffers,
+            images,
             all_positions,
             all_indices,
+            all_uvs,
             vertex_offset,
+            texture,
             current_transform,
         )?;
     }
@@ -208,9 +228,12 @@ fn process_node(
 fn process_primitive(
     primitive: &gltf::Primitive,
     buffers: &[gltf::buffer::Data],
+    images: &[gltf::image::Data],
     all_positions: &mut Vec<Vec3>,
     all_indices: &mut Vec<u32>,
+    all_uvs: &mut Vec<Vec2>,
     vertex_offset: &mut u32,
+    texture: &mut Option<CpuTexture>,
     transform: cgmath::Matrix4<f32>,
 ) -> Result<()> {
     println!("Zpracovávám primitiv s modem: {:?}", primitive.mode());
@@ -236,6 +259,14 @@ fn process_primitive(
 
         let vertex_count = all_positions.len() - start_vertex_count;
         println!("Přidáno {} vrcholů", vertex_count);
+
+        if let Some(tex) = reader.read_tex_coords(0) {
+            for tc in tex.into_f32() {
+                all_uvs.push(vec2(tc[0], 1.0 - tc[1]));
+            }
+        } else {
+            all_uvs.extend(std::iter::repeat(vec2(0.0, 0.0)).take(vertex_count));
+        }
 
         // Získej indexy
         if let Some(indices) = reader.read_indices() {
@@ -274,11 +305,39 @@ fn process_primitive(
         println!("Primitiv nemá pozice vrcholů");
     }
 
+    if texture.is_none() {
+        if let Some(info) = primitive.material().pbr_metallic_roughness().base_color_texture() {
+            let tex = info.texture();
+            let image = &images[tex.source().index()];
+            let data = match image.format {
+                gltf::image::Format::R8G8B8A8 => {
+                    TextureData::RgbaU8(image.pixels.chunks(4).map(|c| [c[0], c[1], c[2], c[3]]).collect())
+                }
+                gltf::image::Format::R8G8B8 => {
+                    TextureData::RgbU8(image.pixels.chunks(3).map(|c| [c[0], c[1], c[2]]).collect())
+                }
+                _ => {
+                    TextureData::RgbaU8(Vec::new())
+                }
+            };
+              if !matches!(data, TextureData::RgbaU8(ref v) if v.is_empty()) {
+                *texture = Some(CpuTexture {
+                    name: "embedded".into(),
+                    data,
+                    width: image.width,
+                    height: image.height,
+                    ..Default::default()
+                });
+              }
+        }
+    }
+
     Ok(())
 }
 
 // Funkce pro vytvoření meshe z viditelných trojúhelníků
-fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
+#[allow(dead_code)]
+fn create_visible_mesh_old(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
     // Paralelní zpracování pozic a indexů
     let triangles_count = triangles.len();
 
@@ -326,6 +385,53 @@ fn create_visible_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, Co
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
 
+fn create_visible_mesh(
+    triangles: &[Triangle],
+    context: &Context,
+    texture: Option<&Texture2DRef>,
+) -> Gm<Mesh, ColorMaterial> {
+    let triangles_count = triangles.len();
+    let mut positions = vec![vec3(0.0, 0.0, 0.0); triangles_count * 3];
+    let mut uvs = vec![vec2(0.0, 0.0); triangles_count * 3];
+    positions
+        .par_chunks_mut(3)
+        .zip(uvs.par_chunks_mut(3))
+        .enumerate()
+        .for_each(|(i, (p_chunk, uv_chunk))| {
+            let tri = &triangles[i];
+            p_chunk[0] = vec3(tri.a.x, tri.a.y, tri.a.z);
+            p_chunk[1] = vec3(tri.b.x, tri.b.y, tri.b.z);
+            p_chunk[2] = vec3(tri.c.x, tri.c.y, tri.c.z);
+            uv_chunk[0] = vec2(tri.uv_a.x, tri.uv_a.y);
+            uv_chunk[1] = vec2(tri.uv_b.x, tri.uv_b.y);
+            uv_chunk[2] = vec2(tri.uv_c.x, tri.uv_c.y);
+        });
+    let mut indices = vec![0u32; triangles_count * 3];
+    indices
+        .par_chunks_mut(3)
+        .enumerate()
+        .for_each(|(i, chunk)| {
+            let base = i as u32 * 3;
+            chunk[0] = base;
+            chunk[1] = base + 1;
+            chunk[2] = base + 2;
+        });
+    let visible_mesh = CpuMesh {
+        positions: Positions::F32(positions),
+        indices: Indices::U32(indices),
+        uvs: Some(uvs),
+        ..Default::default()
+    };
+    let model_color = CONFIG.lock().unwrap().model_color;
+    let material = ColorMaterial {
+        color: model_color,
+        texture: texture.cloned(),
+        render_states: RenderStates::default(),
+        is_transparent: false,
+    };
+    Gm::new(Mesh::new(context, &visible_mesh), material)
+}
+
 // ---------------- Main --------------------------------------------------- //
 
 fn main() -> Result<()> {
@@ -347,7 +453,7 @@ fn main() -> Result<()> {
     // stavová proměnná: název aktuálního souboru a úspěšnost načtení
     let initial_path = Path::new("assets/model.glb");
     println!("📁 Načítám model z: {}", initial_path.display());
-    let (cpu_mesh, _load_status) = load_cpu_mesh(initial_path);
+    let (cpu_mesh, initial_texture, _load_status) = load_cpu_mesh(initial_path);
     println!("✓ Model načten");
 
     let mut loaded_file_name = if initial_path.exists() {
@@ -363,6 +469,9 @@ fn main() -> Result<()> {
     // Add state for file loading
     let mut current_cpu_mesh = cpu_mesh.clone();
     let mut current_triangles = cpu_mesh_to_triangles(&cpu_mesh);
+    let mut current_texture =
+        initial_texture.map(|t| Texture2DRef::from_cpu_texture(&context, &t));
+    let mut show_texture = current_texture.is_some();
     let mut file_loading = false;
 
     // Vytvoření triangles z CPU meshe
@@ -527,6 +636,7 @@ fn main() -> Result<()> {
                 }
                 Message::NewFile {
                     cpu_mesh: new_cpu_mesh,
+                    texture: new_tex,
                     triangles: _,
                     file_name,
                     load_status: _,
@@ -536,6 +646,11 @@ fn main() -> Result<()> {
                     loaded_file_name = file_name;
                     file_loading = false;
                     current_triangles = cpu_mesh_to_triangles(&current_cpu_mesh);
+                    current_texture =
+                        new_tex.map(|t| Texture2DRef::from_cpu_texture(&context, &t));
+                    if current_texture.is_some() {
+                        show_texture = true;
+                    }
                     let next_id = AtomicUsize::new(0);
                     bsp_root_full = Some(build_bsp(
                         &current_triangles,
@@ -543,7 +658,8 @@ fn main() -> Result<()> {
                         cfg.max_bsp_depth,
                         &next_id,
                     ));
-                    total_stats.total_nodes = bsp_root_full.as_ref().unwrap().count_nodes();
+                    total_stats.total_nodes =
+                        bsp_root_full.as_ref().unwrap().count_nodes();
                     let next_id = AtomicUsize::new(0);
                     bsp_root_preview =
                         Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
@@ -634,6 +750,7 @@ fn main() -> Result<()> {
             |ctx| {
                 crate::gui::draw_left_panel(
                     ctx,
+                    &context,
                     mode,
                     &mut loaded_file_name,
                     &mut file_loading,
@@ -641,12 +758,14 @@ fn main() -> Result<()> {
                     &rx,
                     &mut current_cpu_mesh,
                     &mut current_triangles,
+                    &mut current_texture,
                     &mut bsp_root_preview,
                     &mut selected_node,
                     &mut show_splitting_plane,
                     &mut disable_culling,
                     &mut show_loaded_model,
                     &mut show_selected_model,
+                    &mut show_texture,
                     &mut show_spectator_marker,
                     &mut spectator_state,
                     &mut third_person_state,
@@ -742,7 +861,11 @@ fn main() -> Result<()> {
         }
 
         let base_model = if !normal_tris.is_empty() {
-            Some(create_visible_mesh(&normal_tris, &context))
+            Some(create_visible_mesh(
+                &normal_tris,
+                &context,
+                if show_texture { current_texture.as_ref() } else { None },
+            ))
         } else {
             None
         };


### PR DESCRIPTION
## Summary
- support UV coordinates in BSP triangles and CPU mesh conversion
- load textures from GLTF files and allow replacing/turning them off via UI
- document updated GLTF loading functions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab793f4c80832f98397ab02cb3d281

## Summary by Sourcery

Add support for loading and displaying textures from GLTF assets, propagate UV coordinates through mesh processing, and provide UI controls to load and toggle textures at runtime.

New Features:
- Load embedded base color textures from GLTF/GLB files and include them as CpuTexture
- Add a UI button to load external image files as textures and a checkbox to toggle texture display
- Extend the rendering pipeline to accept an optional Texture2DRef for mesh materials

Enhancements:
- Extend CpuMesh and Triangle types to include UV coordinates and propagate them through mesh import and BSP conversion
- Refactor load_cpu_mesh, load_gltf_with_gltf_crate, and Message::NewFile to return and handle optional textures

Documentation:
- Update FUNCTIONS.md to document the extended load_cpu_mesh and load_gltf_with_gltf_crate functions with texture support

Tests:
- Adjust BSP triangle tests to initialize new UV fields with default coordinates