### PR TITLE
Fix delayed texture loading by routing updates through channel

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -36,7 +36,7 @@ source code so you can jump directly to the implementation.
 ## `src/gui.rs`
 - [`layout_bsp_tree`](src/gui.rs#L13-L35) – compute plot positions for BSP
   nodes.
-- [`draw_left_panel`](src.gui.rs#L119-L143) – render the left control panel and
+- [`draw_left_panel`](src/gui.rs#L125-L438) – render the left control panel and
   handle UI interactions.
 
 ## `src/input.rs`

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -3,8 +3,7 @@ use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicUsize;
-use three_d::{Srgba, Texture2DRef, CpuTexture};
+use three_d::{CpuTexture, Srgba};
 
 struct TreePlotData {
     positions: HashMap<usize, PlotPoint>,
@@ -125,15 +124,11 @@ fn draw_bsp_tree_window(
 
 pub fn draw_left_panel(
     ctx: &egui::Context,
-    gl: &three_d::Context,
     mode: crate::camera::CamMode,
     loaded_file_name: &mut String,
     file_loading: &mut bool,
     tx_gui: &std::sync::mpsc::Sender<crate::Message>,
-    rx: &std::sync::mpsc::Receiver<crate::Message>,
     current_cpu_mesh: &mut three_d::CpuMesh,
-    current_triangles: &mut Vec<crate::bsp::Triangle>,
-    current_texture: &mut Option<Texture2DRef>,
     bsp_root_preview: &mut Option<crate::bsp::BspNode>,
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
@@ -193,13 +188,15 @@ pub fn draw_left_panel(
                     .add_filter("Image", &["png", "jpg", "jpeg"])
                     .pick_file()
                 {
-                    if let Ok(tex) =
-                        three_d_asset::io::load_and_deserialize::<CpuTexture>(&path)
-                    {
-                        *current_texture =
-                            Some(Texture2DRef::from_cpu_texture(gl, &tex));
-                        *show_texture = true;
-                    }
+                    let tx_gui_clone = tx_gui.clone();
+                    let path_clone = path.clone();
+                    std::thread::spawn(move || {
+                        if let Ok(tex) =
+                            three_d_asset::io::load_and_deserialize::<CpuTexture>(&path_clone)
+                        {
+                            let _ = tx_gui_clone.send(crate::Message::NewTexture { texture: tex });
+                        }
+                    });
                 }
             }
             ui.checkbox(show_texture, "Zobrazit texturu");
@@ -413,37 +410,6 @@ pub fn draw_left_panel(
             ));
             ui.checkbox(show_spectator_marker, "Zobrazit pozici a směr spectatoru");
 
-            if let Ok(msg) = rx.try_recv() {
-                match msg {
-                    crate::Message::NewFile {
-                        cpu_mesh,
-                        texture,
-                        file_name,
-                        load_status: _,
-                        triangles: _,
-                        bsp_tree: _,
-                    } => {
-                        *current_cpu_mesh = cpu_mesh;
-                        *loaded_file_name = file_name;
-                        *file_loading = false;
-                        *current_triangles =
-                            crate::bsp::cpu_mesh_to_triangles(current_cpu_mesh);
-                        *current_texture =
-                            texture.map(|t| Texture2DRef::from_cpu_texture(gl, &t));
-                        if current_texture.is_some() {
-                            *show_texture = true;
-                        }
-                        let next_id = AtomicUsize::new(0);
-                        *bsp_root_preview = Some(crate::bsp::build_bsp(
-                            current_triangles,
-                            0,
-                            *branch_limit,
-                            &next_id,
-                        ));
-                    }
-                    _ => {}
-                }
-            }
         });
     });
     if *config_window_open {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ enum Message {
         load_status: String,
         bsp_tree: BspNode,
     },
+    NewTexture { texture: CpuTexture },
 }
 
 // helper: načte CpuMesh z .glb/.gltf pomocí gltf crate
@@ -623,8 +624,8 @@ fn main() -> Result<()> {
         third_person_glow.material.color = cfg.highlight_color;
         camera_direction_ray.material.color = cfg.highlight_color;
 
-        // Zkontroluj, zda background thread dokončil stavbu BSP stromu
-        if let Ok(message) = rx.try_recv() {
+        // Zpracuj zprávy z background vláken
+        while let Ok(message) = rx.try_recv() {
             match message {
                 Message::InitialTree(tree) => {
                     total_stats.total_nodes = tree.count_nodes();
@@ -665,6 +666,10 @@ fn main() -> Result<()> {
                         Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
                     total_stats.total_triangles = current_triangles.len() as u32;
                     println!("✅ Nový model a BSP strom načteny!");
+                }
+                Message::NewTexture { texture: tex } => {
+                    current_texture = Some(Texture2DRef::from_cpu_texture(&context, &tex));
+                    show_texture = true;
                 }
             }
         }
@@ -750,15 +755,11 @@ fn main() -> Result<()> {
             |ctx| {
                 crate::gui::draw_left_panel(
                     ctx,
-                    &context,
                     mode,
                     &mut loaded_file_name,
                     &mut file_loading,
                     &tx_gui,
-                    &rx,
                     &mut current_cpu_mesh,
-                    &mut current_triangles,
-                    &mut current_texture,
                     &mut bsp_root_preview,
                     &mut selected_node,
                     &mut show_splitting_plane,


### PR DESCRIPTION
## Summary
- load textures asynchronously and send to main loop over channel
- centralize message handling with new `NewTexture` variant for instant GPU update
- update function docs and remove GUI-side channel reads

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab83749cf4832f862e885e31d7d210

## Summary by Sourcery

Enable asynchronous texture loading by routing loaded CpuTexture messages through a NewTexture channel variant, centralize all channel message handling in the main loop for immediate GPU updates, and simplify the GUI API by removing GUI-side channel reads.

New Features:
- Load textures asynchronously on a background thread and send them via a new NewTexture message.

Enhancements:
- Add a Message::NewTexture variant and process it in the main loop for instant GPU texture updates.
- Consolidate channel message processing in the main loop using a while-let loop and remove GUI-side reads.
- Simplify draw_left_panel signature by dropping unused context and receiver parameters.

Documentation:
- Expand draw_left_panel link range in FUNCTION.md.