### PR TITLE
Fix highlight color picker shifting

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -450,29 +450,35 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
                 ui.color_edit_button_rgb(&mut cfg.bg_color);
             });
 
-            let mut color = egui::Color32::from_rgba_unmultiplied(
+            let mut color = [
                 cfg.model_color.r,
                 cfg.model_color.g,
                 cfg.model_color.b,
                 cfg.model_color.a,
-            );
+            ];
             ui.horizontal(|ui| {
                 ui.label("Model");
-                if ui.color_edit_button_srgba(&mut color).changed() {
-                    cfg.model_color = Srgba::new(color.r(), color.g(), color.b(), color.a());
+                if ui
+                    .color_edit_button_srgba_unmultiplied(&mut color)
+                    .changed()
+                {
+                    cfg.model_color = Srgba::new(color[0], color[1], color[2], color[3]);
                 }
             });
 
-            let mut hcol = egui::Color32::from_rgba_unmultiplied(
+            let mut hcol = [
                 cfg.highlight_color.r,
                 cfg.highlight_color.g,
                 cfg.highlight_color.b,
                 cfg.highlight_color.a,
-            );
+            ];
             ui.horizontal(|ui| {
                 ui.label("Highlight");
-                if ui.color_edit_button_srgba(&mut hcol).changed() {
-                    cfg.highlight_color = Srgba::new(hcol.r(), hcol.g(), hcol.b(), hcol.a());
+                if ui
+                    .color_edit_button_srgba_unmultiplied(&mut hcol)
+                    .changed()
+                {
+                    cfg.highlight_color = Srgba::new(hcol[0], hcol[1], hcol[2], hcol[3]);
                 }
             });
 
@@ -480,16 +486,20 @@ fn draw_config_window(ctx: &egui::Context, open: &mut bool) {
                 egui::Slider::new(&mut cfg.ambient_light_intensity, 0.0..=5.0)
                     .text("Ambient intensity"),
             );
-            let mut acol = egui::Color32::from_rgba_unmultiplied(
+            let mut acol = [
                 cfg.ambient_light_color.r,
                 cfg.ambient_light_color.g,
                 cfg.ambient_light_color.b,
                 cfg.ambient_light_color.a,
-            );
+            ];
             ui.horizontal(|ui| {
                 ui.label("Ambient color");
-                if ui.color_edit_button_srgba(&mut acol).changed() {
-                    cfg.ambient_light_color = Srgba::new(acol.r(), acol.g(), acol.b(), acol.a());
+                if ui
+                    .color_edit_button_srgba_unmultiplied(&mut acol)
+                    .changed()
+                {
+                    cfg.ambient_light_color =
+                        Srgba::new(acol[0], acol[1], acol[2], acol[3]);
                 }
             });
 


### PR DESCRIPTION
## Summary
- switch model, highlight, and ambient colors to `color_edit_button_srgba_unmultiplied`
- prevent alpha-premultiplication from darkening highlight color selection

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68ac64cbe8e0832f8100471ba0b7b15a