### PR TITLE
Remove manual model loading and add default texture

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -125,8 +125,7 @@ fn draw_bsp_tree_window(
 pub fn draw_left_panel(
     ctx: &egui::Context,
     mode: crate::camera::CamMode,
-    loaded_file_name: &mut String,
-    file_loading: &mut bool,
+    loaded_file_name: &str,
     tx_gui: &std::sync::mpsc::Sender<crate::Message>,
     current_cpu_mesh: &mut three_d::CpuMesh,
     bsp_root_preview: &mut Option<crate::bsp::BspNode>,
@@ -156,33 +155,9 @@ pub fn draw_left_panel(
             ui.label(format!("Režim: {:?}", mode));
 
             ui.separator();
-            ui.heading("Načtení modelu");
+            ui.heading("Model");
             ui.label("Aktuální model:");
-            ui.label(loaded_file_name.as_str());
-
-            if ui.button("📁 Načíst nový model").clicked() {
-                if let Some(path) = rfd::FileDialog::new()
-                    .add_filter("GLTF/GLB files", &["gltf", "glb"])
-                    .pick_file()
-                {
-                    *file_loading = true;
-                    let path_clone = path.clone();
-                    let file_name_clone = path.file_name().unwrap().to_string_lossy().into_owned();
-                    let tx_gui_clone = tx_gui.clone();
-                    std::thread::spawn(move || {
-                        let (new_cpu_mesh, new_texture, load_status) =
-                            crate::load_cpu_mesh(&path_clone);
-                        let _ = tx_gui_clone.send(crate::Message::NewFile {
-                            cpu_mesh: new_cpu_mesh,
-                            texture: new_texture,
-                            file_name: file_name_clone,
-                            load_status,
-                            triangles: Vec::new(),
-                            bsp_tree: crate::bsp::BspNode::new_leaf(Vec::new(), 0),
-                        });
-                    });
-                }
-            }
+            ui.label(loaded_file_name);
             if ui.button("📷 Načíst texturu").clicked() {
                 if let Some(path) = rfd::FileDialog::new()
                     .add_filter("Image", &["png", "jpg", "jpeg"])
@@ -200,15 +175,6 @@ pub fn draw_left_panel(
                 }
             }
             ui.checkbox(show_texture, "Zobrazit texturu");
-
-            if *file_loading {
-                ui.add(
-                    egui::ProgressBar::new(0.0)
-                        .desired_width(ui.available_width())
-                        .text("Načítání modelu a stavba BSP stromu...")
-                        .animate(true),
-                );
-            }
 
             if bsp_root_preview.is_none() {
                 ui.separator();

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,14 +47,6 @@ mod input;
 #[derive(Debug)]
 enum Message {
     InitialTree(BspNode),
-    NewFile {
-        cpu_mesh: CpuMesh,
-        texture: Option<CpuTexture>,
-        triangles: Vec<Triangle>,
-        file_name: String,
-        load_status: String,
-        bsp_tree: BspNode,
-    },
     NewTexture { texture: CpuTexture },
 }
 
@@ -433,6 +425,25 @@ fn create_visible_mesh(
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
 
+fn default_checker_texture() -> CpuTexture {
+    CpuTexture {
+        name: "default_checker".into(),
+        data: three_d_asset::texture::TextureData::RgbaU8(vec![
+            [255, 255, 255, 255],
+            [0, 0, 0, 255],
+            [0, 0, 0, 255],
+            [255, 255, 255, 255],
+        ]),
+        width: 2,
+        height: 2,
+        min_filter: three_d_asset::texture::Interpolation::Nearest,
+        mag_filter: three_d_asset::texture::Interpolation::Nearest,
+        mipmap: Some(three_d_asset::texture::Mipmap::default()),
+        wrap_s: three_d_asset::texture::Wrapping::Repeat,
+        wrap_t: three_d_asset::texture::Wrapping::Repeat,
+    }
+}
+
 // ---------------- Main --------------------------------------------------- //
 
 fn main() -> Result<()> {
@@ -454,10 +465,13 @@ fn main() -> Result<()> {
     // stavová proměnná: název aktuálního souboru a úspěšnost načtení
     let initial_path = Path::new("assets/model.glb");
     println!("📁 Načítám model z: {}", initial_path.display());
-    let (cpu_mesh, initial_texture, _load_status) = load_cpu_mesh(initial_path);
+    let (cpu_mesh, mut initial_texture, _load_status) = load_cpu_mesh(initial_path);
     println!("✓ Model načten");
+    if initial_texture.is_none() {
+        initial_texture = Some(default_checker_texture());
+    }
 
-    let mut loaded_file_name = if initial_path.exists() {
+    let loaded_file_name = if initial_path.exists() {
         initial_path
             .file_name()
             .unwrap()
@@ -469,11 +483,10 @@ fn main() -> Result<()> {
 
     // Add state for file loading
     let mut current_cpu_mesh = cpu_mesh.clone();
-    let mut current_triangles = cpu_mesh_to_triangles(&cpu_mesh);
+    let current_triangles = cpu_mesh_to_triangles(&cpu_mesh);
     let mut current_texture =
         initial_texture.map(|t| Texture2DRef::from_cpu_texture(&context, &t));
     let mut show_texture = current_texture.is_some();
-    let mut file_loading = false;
 
     // Vytvoření triangles z CPU meshe
     println!("🔺 Převádím mesh na trojúhelníky...");
@@ -635,38 +648,6 @@ fn main() -> Result<()> {
                         Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
                     println!("✅ BSP strom úspěšně načten do GUI!");
                 }
-                Message::NewFile {
-                    cpu_mesh: new_cpu_mesh,
-                    texture: new_tex,
-                    triangles: _,
-                    file_name,
-                    load_status: _,
-                    bsp_tree: _,
-                } => {
-                    current_cpu_mesh = new_cpu_mesh;
-                    loaded_file_name = file_name;
-                    file_loading = false;
-                    current_triangles = cpu_mesh_to_triangles(&current_cpu_mesh);
-                    current_texture =
-                        new_tex.map(|t| Texture2DRef::from_cpu_texture(&context, &t));
-                    if current_texture.is_some() {
-                        show_texture = true;
-                    }
-                    let next_id = AtomicUsize::new(0);
-                    bsp_root_full = Some(build_bsp(
-                        &current_triangles,
-                        0,
-                        cfg.max_bsp_depth,
-                        &next_id,
-                    ));
-                    total_stats.total_nodes =
-                        bsp_root_full.as_ref().unwrap().count_nodes();
-                    let next_id = AtomicUsize::new(0);
-                    bsp_root_preview =
-                        Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
-                    total_stats.total_triangles = current_triangles.len() as u32;
-                    println!("✅ Nový model a BSP strom načteny!");
-                }
                 Message::NewTexture { texture: tex } => {
                     current_texture = Some(Texture2DRef::from_cpu_texture(&context, &tex));
                     show_texture = true;
@@ -756,8 +737,7 @@ fn main() -> Result<()> {
                 crate::gui::draw_left_panel(
                     ctx,
                     mode,
-                    &mut loaded_file_name,
-                    &mut file_loading,
+                    loaded_file_name.as_str(),
                     &tx_gui,
                     &mut current_cpu_mesh,
                     &mut bsp_root_preview,


### PR DESCRIPTION
## Summary
- drop the "load model" button so the viewer always uses the built-in model
- keep texture loading and show model name only
- add a small checkerboard texture as fallback when the model lacks one

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ac6f440c80832f828fb8ac9eeaef0d