### PR TITLE
Synchronize branch limit with configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -510,6 +510,7 @@ fn main() -> Result<()> {
     let mut config_window_open = false;
     let mut branch_limit = cfg.default_branch_limit;
     let mut last_branch_limit = branch_limit;
+    let mut last_default_branch_limit = cfg.default_branch_limit;
     let mut limit_culling = false;
 
     // stav pro vykreslovaný mesh
@@ -619,6 +620,15 @@ fn main() -> Result<()> {
         spectator_glow.material.color = cfg.highlight_color;
         third_person_glow.material.color = cfg.highlight_color;
         camera_direction_ray.material.color = cfg.highlight_color;
+
+        // Synchronize branch limit with configuration changes
+        if branch_limit > cfg.max_bsp_depth {
+            branch_limit = cfg.max_bsp_depth;
+        }
+        if cfg.default_branch_limit != last_default_branch_limit {
+            branch_limit = cfg.default_branch_limit.min(cfg.max_bsp_depth);
+            last_default_branch_limit = cfg.default_branch_limit;
+        }
 
         // Zkontroluj, zda background thread dokončil stavbu BSP stromu
         if let Ok(message) = rx.try_recv() {


### PR DESCRIPTION
## Summary
- keep branch limit slider in sync with configurable defaults and maximum depth

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1896b5308832faa5f2d50ca8e500d

## Summary by Sourcery

Synchronize the branch limit slider with configuration by clamping it to the maximum BSP depth and resetting it when the default limit changes

Enhancements:
- Add tracking of the last default branch limit to detect configuration updates
- Clamp the branch limit to the maximum BSP depth on each update
- Reset the branch limit to the (new) default value, bounded by the maximum depth, when the default changes