### PR TITLE
Sync camera speed config with PageUp/PageDown adjustments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -947,10 +947,14 @@ fn main() -> Result<()> {
         // Zpracování změny rychlosti pomocí PageUp/PageDown přes InputManager
         if input_manager.is_key_pressed(KeyCode::PageUp) {
             cam.speed *= cfg.speed_adjustment_factor;
+            // Keep configuration in sync with runtime speed adjustments
+            CONFIG.lock().unwrap().default_camera_speed = cam.speed;
             println!("Rychlost zvýšena na: {:.1}", cam.speed);
         }
         if input_manager.is_key_pressed(KeyCode::PageDown) {
             cam.speed /= cfg.speed_adjustment_factor;
+            // Keep configuration in sync with runtime speed adjustments
+            CONFIG.lock().unwrap().default_camera_speed = cam.speed;
             println!("Rychlost snížena na: {:.1}", cam.speed);
         }
 


### PR DESCRIPTION
## Summary
- keep `CONFIG.default_camera_speed` synchronized when adjusting speed with PageUp/PageDown

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b216d6ab68832f9f705abe49bd90c7

## Summary by Sourcery

Synchronize the configuration's default camera speed whenever the camera speed is adjusted using PageUp/PageDown

Enhancements:
- Update CONFIG.default_camera_speed after increasing camera speed with PageUp
- Update CONFIG.default_camera_speed after decreasing camera speed with PageDown