### PR TITLE
Add configurable marker and arrow colors

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -62,13 +62,14 @@ impl FreeCamera {
             self.yaw += tilt_value * self.look_speed * dt;
         }
         if input_manager.is_key_pressed(KeyCode::Up) {
-            let limit = CONFIG.lock().unwrap().pitch_limit;
-            self.pitch = (self.pitch + self.look_speed * dt).clamp(-limit, limit);
+            self.pitch += self.look_speed * dt;
         }
         if input_manager.is_key_pressed(KeyCode::Down) {
-            let limit = CONFIG.lock().unwrap().pitch_limit;
-            self.pitch = (self.pitch - self.look_speed * dt).clamp(-limit, limit);
+            self.pitch -= self.look_speed * dt;
         }
+        // Wrap pitch to keep it within [-PI, PI] allowing full 360° rotation
+        self.pitch = (self.pitch + std::f32::consts::PI) % (2.0 * std::f32::consts::PI)
+            - std::f32::consts::PI;
     }
 
     pub fn cam(&self, vp: Viewport) -> Camera {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub bg_color: [f32; 3],
     pub model_color: Srgba,
     pub highlight_color: Srgba,
+    pub marker_color: Srgba,
+    pub arrow_color: Srgba,
     pub ambient_light_intensity: f32,
     pub ambient_light_color: Srgba,
 
@@ -38,7 +40,6 @@ pub struct Config {
     // ---------------------------------------------------------------------
     pub camera_speed: f32,
     pub look_speed: f32,
-    pub pitch_limit: f32,
     pub default_fov_deg: f32,
     pub near_plane: f32,
     pub far_plane: f32,
@@ -56,6 +57,8 @@ impl Default for Config {
             bg_color: [0.1, 0.1, 0.1],
             model_color: Srgba::new(100, 150, 255, 255),
             highlight_color: Srgba::new(255, 50, 50, 150),
+            marker_color: Srgba::new(50, 255, 50, 150),
+            arrow_color: Srgba::new(255, 255, 50, 150),
             ambient_light_intensity: 1.0,
             ambient_light_color: Srgba::WHITE,
             bsp_tree_text_size: 16.0,
@@ -66,7 +69,6 @@ impl Default for Config {
             min_triangles_per_leaf: 20,
             camera_speed: 4.0,
             look_speed: 2.0,
-            pitch_limit: 1.5,
             default_fov_deg: 60.0,
             near_plane: 0.1,
             far_plane: 1000.0,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -436,7 +436,14 @@ pub fn draw_left_panel(
         });
     });
     if *config_window_open {
-        draw_config_window(ctx, cam, config_window_open);
+        draw_config_window(
+            ctx,
+            cam,
+            spectator_state,
+            third_person_state,
+            mode,
+            config_window_open,
+        );
     }
     if *selected_node_help_open {
         egui::Window::new("Vysvětlivky - Vybraný uzel")
@@ -460,7 +467,14 @@ pub fn draw_left_panel(
     }
 }
 
-fn draw_config_window(ctx: &egui::Context, cam: &mut crate::camera::FreeCamera, open: &mut bool) {
+fn draw_config_window(
+    ctx: &egui::Context,
+    cam: &mut crate::camera::FreeCamera,
+    spectator_state: &mut crate::camera::CameraState,
+    third_person_state: &mut crate::camera::CameraState,
+    mode: crate::camera::CamMode,
+    open: &mut bool,
+) {
     egui::Window::new("Config")
         .open(open)
         .vscroll(true)
@@ -496,6 +510,32 @@ fn draw_config_window(ctx: &egui::Context, cam: &mut crate::camera::FreeCamera, 
                 ui.label("Highlight");
                 if ui.color_edit_button_srgba(&mut hcol).changed() {
                     cfg.highlight_color = Srgba::new(hcol.r(), hcol.g(), hcol.b(), hcol.a());
+                }
+            });
+
+            let mut mcol = egui::Color32::from_rgba_unmultiplied(
+                cfg.marker_color.r,
+                cfg.marker_color.g,
+                cfg.marker_color.b,
+                cfg.marker_color.a,
+            );
+            ui.horizontal(|ui| {
+                ui.label("Marker");
+                if ui.color_edit_button_srgba(&mut mcol).changed() {
+                    cfg.marker_color = Srgba::new(mcol.r(), mcol.g(), mcol.b(), mcol.a());
+                }
+            });
+
+            let mut dircol = egui::Color32::from_rgba_unmultiplied(
+                cfg.arrow_color.r,
+                cfg.arrow_color.g,
+                cfg.arrow_color.b,
+                cfg.arrow_color.a,
+            );
+            ui.horizontal(|ui| {
+                ui.label("Arrow");
+                if ui.color_edit_button_srgba(&mut dircol).changed() {
+                    cfg.arrow_color = Srgba::new(dircol.r(), dircol.g(), dircol.b(), dircol.a());
                 }
             });
 
@@ -555,9 +595,8 @@ fn draw_config_window(ctx: &egui::Context, cam: &mut crate::camera::FreeCamera, 
             {
                 cfg.look_speed = cam.look_speed;
             }
-            ui.add(egui::Slider::new(&mut cfg.pitch_limit, 0.1..=3.14).text("Pitch limit"));
             ui.add(egui::Slider::new(&mut cfg.default_fov_deg, 30.0..=120.0).text("FOV deg"));
-            ui.add(egui::Slider::new(&mut cfg.near_plane, 0.01..=1.0).text("Near plane"));
+            ui.add(egui::Slider::new(&mut cfg.near_plane, 0.01..=10.0).text("Near plane"));
             ui.add(egui::Slider::new(&mut cfg.far_plane, 10.0..=5000.0).text("Far plane"));
             ui.add(
                 egui::Slider::new(&mut cfg.camera_switch_cooldown, 0.1..=10.0)
@@ -566,15 +605,41 @@ fn draw_config_window(ctx: &egui::Context, cam: &mut crate::camera::FreeCamera, 
 
             ui.horizontal(|ui| {
                 ui.label("Spectator pos");
-                ui.add(egui::DragValue::new(&mut cfg.default_spectator_pos.x));
-                ui.add(egui::DragValue::new(&mut cfg.default_spectator_pos.y));
-                ui.add(egui::DragValue::new(&mut cfg.default_spectator_pos.z));
+                let mut changed = false;
+                changed |= ui
+                    .add(egui::DragValue::new(&mut spectator_state.pos.x))
+                    .changed();
+                changed |= ui
+                    .add(egui::DragValue::new(&mut spectator_state.pos.y))
+                    .changed();
+                changed |= ui
+                    .add(egui::DragValue::new(&mut spectator_state.pos.z))
+                    .changed();
+                if changed {
+                    cfg.default_spectator_pos = spectator_state.pos;
+                    if mode == crate::camera::CamMode::Spectator {
+                        cam.pos = spectator_state.pos;
+                    }
+                }
             });
             ui.horizontal(|ui| {
                 ui.label("Third person pos");
-                ui.add(egui::DragValue::new(&mut cfg.default_third_person_pos.x));
-                ui.add(egui::DragValue::new(&mut cfg.default_third_person_pos.y));
-                ui.add(egui::DragValue::new(&mut cfg.default_third_person_pos.z));
+                let mut changed = false;
+                changed |= ui
+                    .add(egui::DragValue::new(&mut third_person_state.pos.x))
+                    .changed();
+                changed |= ui
+                    .add(egui::DragValue::new(&mut third_person_state.pos.y))
+                    .changed();
+                changed |= ui
+                    .add(egui::DragValue::new(&mut third_person_state.pos.z))
+                    .changed();
+                if changed {
+                    cfg.default_third_person_pos = third_person_state.pos;
+                    if mode == crate::camera::CamMode::ThirdPerson {
+                        cam.pos = third_person_state.pos;
+                    }
+                }
             });
             ui.add(
                 egui::Slider::new(&mut cfg.camera_marker_scale, 0.01..=1.0).text("Marker scale"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,7 +540,7 @@ fn main() -> Result<()> {
     let spectator_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: cfg.highlight_color,
+            albedo: cfg.marker_color,
             ..Default::default()
         },
     );
@@ -548,7 +548,7 @@ fn main() -> Result<()> {
     let third_person_glow_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: cfg.highlight_color,
+            albedo: cfg.marker_color,
             ..Default::default()
         },
     );
@@ -557,7 +557,7 @@ fn main() -> Result<()> {
     let direction_material = ColorMaterial::new_opaque(
         &context,
         &CpuMaterial {
-            albedo: cfg.highlight_color,
+            albedo: cfg.arrow_color,
             ..Default::default()
         },
     );
@@ -626,9 +626,9 @@ fn main() -> Result<()> {
         // Apply dynamic configuration updates
         ambient_light.intensity = cfg.ambient_light_intensity;
         ambient_light.color = cfg.ambient_light_color;
-        spectator_glow.material.color = cfg.highlight_color;
-        third_person_glow.material.color = cfg.highlight_color;
-        camera_direction_ray.material.color = cfg.highlight_color;
+        spectator_glow.material.color = cfg.marker_color;
+        third_person_glow.material.color = cfg.marker_color;
+        camera_direction_ray.material.color = cfg.arrow_color;
 
         // Synchronize branch limit with configuration changes
         if branch_limit > cfg.max_bsp_depth {


### PR DESCRIPTION
## Summary
- Allow full 360° camera pitch rotation
- Separate marker and direction arrow colors configurable in settings
- Update coordinate inputs to control current camera positions and raise near plane limit

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b21cffb01c832fa9396d200dcb6f47

## Summary by Sourcery

Improve camera configurability by enabling unrestricted pitch rotation, refining live position controls, and adding distinct marker and arrow color settings

New Features:
- Support full 360° camera pitch rotation by replacing clamped pitch with wrapping logic
- Introduce separate marker and arrow color pickers in the configuration window

Enhancements:
- Extend near-plane slider range to 0.01–10 and remove the pitch-limit setting
- Make spectator and third-person position inputs immediately update the active camera