### PR TITLE
Allow translucent model rendering

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -498,12 +498,11 @@ fn draw_config_window(
                 if egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut color,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 )
                 .changed()
                 {
-                    cfg.model_color =
-                        Srgba::new(color.r(), color.g(), color.b(), color.a());
+                    cfg.model_color = Srgba::new(color.r(), color.g(), color.b(), color.a());
                 }
             });
 
@@ -522,8 +521,7 @@ fn draw_config_window(
                 )
                 .changed()
                 {
-                    cfg.highlight_color =
-                        Srgba::new(hcol.r(), hcol.g(), hcol.b(), hcol.a());
+                    cfg.highlight_color = Srgba::new(hcol.r(), hcol.g(), hcol.b(), hcol.a());
                 }
             });
 
@@ -542,8 +540,7 @@ fn draw_config_window(
                 )
                 .changed()
                 {
-                    cfg.marker_color =
-                        Srgba::new(mcol.r(), mcol.g(), mcol.b(), mcol.a());
+                    cfg.marker_color = Srgba::new(mcol.r(), mcol.g(), mcol.b(), mcol.a());
                 }
             });
 
@@ -562,8 +559,7 @@ fn draw_config_window(
                 )
                 .changed()
                 {
-                    cfg.arrow_color =
-                        Srgba::new(dircol.r(), dircol.g(), dircol.b(), dircol.a());
+                    cfg.arrow_color = Srgba::new(dircol.r(), dircol.g(), dircol.b(), dircol.a());
                 }
             });
 
@@ -586,8 +582,7 @@ fn draw_config_window(
                 )
                 .changed()
                 {
-                    cfg.ambient_light_color =
-                        Srgba::new(acol.r(), acol.g(), acol.b(), acol.a());
+                    cfg.ambient_light_color = Srgba::new(acol.r(), acol.g(), acol.b(), acol.a());
                 }
             });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,13 +381,15 @@ fn create_visible_mesh_old(triangles: &[Triangle], context: &Context) -> Gm<Mesh
 
     // Vytvoření materiálu a modelu
     let model_color = CONFIG.lock().unwrap().model_color;
-    let material = ColorMaterial::new_opaque(
-        context,
-        &CpuMaterial {
-            albedo: model_color,
-            ..Default::default()
-        },
-    );
+    let cpu_material = CpuMaterial {
+        albedo: model_color,
+        ..Default::default()
+    };
+    let material = if model_color.a < 255 {
+        ColorMaterial::new_transparent(context, &cpu_material)
+    } else {
+        ColorMaterial::new_opaque(context, &cpu_material)
+    };
 
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
@@ -430,11 +432,20 @@ fn create_visible_mesh(
         ..Default::default()
     };
     let model_color = CONFIG.lock().unwrap().model_color;
+    let is_transparent = model_color.a < 255;
+    let render_states = if is_transparent {
+        RenderStates {
+            blend: Blend::TRANSPARENCY,
+            ..Default::default()
+        }
+    } else {
+        RenderStates::default()
+    };
     let material = ColorMaterial {
         color: model_color,
         texture: texture.cloned(),
-        render_states: RenderStates::default(),
-        is_transparent: false,
+        render_states,
+        is_transparent,
     };
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
@@ -524,43 +535,51 @@ fn main() -> Result<()> {
 
     // stav pro vykreslovaný mesh
     let _glb_path: Option<PathBuf> = None;
-    let material = ColorMaterial::new_opaque(
-        &context,
-        &CpuMaterial {
-            albedo: cfg.model_color,
-            ..Default::default()
-        },
-    );
+    let cpu_material = CpuMaterial {
+        albedo: cfg.model_color,
+        ..Default::default()
+    };
+    let material = if cfg.model_color.a < 255 {
+        ColorMaterial::new_transparent(&context, &cpu_material)
+    } else {
+        ColorMaterial::new_opaque(&context, &cpu_material)
+    };
     let _model = Gm::new(Mesh::new(&context, &cpu_mesh), material.clone());
 
     // Glow efekty pro pozice kamer
     let glow_mesh = CpuMesh::sphere(16);
 
     // Materiály pro glow efekty
-    let spectator_glow_material = ColorMaterial::new_opaque(
-        &context,
-        &CpuMaterial {
-            albedo: cfg.marker_color,
-            ..Default::default()
-        },
-    );
+    let spectator_cpu_material = CpuMaterial {
+        albedo: cfg.marker_color,
+        ..Default::default()
+    };
+    let spectator_glow_material = if cfg.marker_color.a < 255 {
+        ColorMaterial::new_transparent(&context, &spectator_cpu_material)
+    } else {
+        ColorMaterial::new_opaque(&context, &spectator_cpu_material)
+    };
 
-    let third_person_glow_material = ColorMaterial::new_opaque(
-        &context,
-        &CpuMaterial {
-            albedo: cfg.marker_color,
-            ..Default::default()
-        },
-    );
+    let third_person_cpu_material = CpuMaterial {
+        albedo: cfg.marker_color,
+        ..Default::default()
+    };
+    let third_person_glow_material = if cfg.marker_color.a < 255 {
+        ColorMaterial::new_transparent(&context, &third_person_cpu_material)
+    } else {
+        ColorMaterial::new_opaque(&context, &third_person_cpu_material)
+    };
 
     // Materiál pro směrový paprsek kamery
-    let direction_material = ColorMaterial::new_opaque(
-        &context,
-        &CpuMaterial {
-            albedo: cfg.arrow_color,
-            ..Default::default()
-        },
-    );
+    let direction_cpu_material = CpuMaterial {
+        albedo: cfg.arrow_color,
+        ..Default::default()
+    };
+    let direction_material = if cfg.arrow_color.a < 255 {
+        ColorMaterial::new_transparent(&context, &direction_cpu_material)
+    } else {
+        ColorMaterial::new_opaque(&context, &direction_cpu_material)
+    };
 
     let mut spectator_glow = Gm::new(Mesh::new(&context, &glow_mesh), spectator_glow_material);
     let mut third_person_glow =


### PR DESCRIPTION
## Summary
- let users adjust model alpha in the config UI
- render models, markers and arrows with transparency when alpha < 255

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b223c5a280832f899508c514c5c693

## Summary by Sourcery

Enable translucent rendering for models, markers, arrows and ambient lights based on configurable alpha values and update the GUI to adjust alpha.

New Features:
- Allow users to adjust alpha channels for model, marker, arrow and ambient light colors in the configuration UI
- Render models, markers, arrows and ambient effects with transparency when their alpha value is below full opacity

Enhancements:
- Use transparent materials and blend states when color alpha is less than 255 and default to opaque otherwise
- Switch EGUi color pickers to OnlyBlend alpha mode to support translucent color selection