### PR TITLE
Allow adjusting alpha in color settings

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -517,7 +517,7 @@ fn draw_config_window(
                 if egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut hcol,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 )
                 .changed()
                 {
@@ -536,7 +536,7 @@ fn draw_config_window(
                 if egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut mcol,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 )
                 .changed()
                 {
@@ -555,7 +555,7 @@ fn draw_config_window(
                 if egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut dircol,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 )
                 .changed()
                 {
@@ -578,7 +578,7 @@ fn draw_config_window(
                 if egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut acol,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 )
                 .changed()
                 {
@@ -594,7 +594,7 @@ fn draw_config_window(
                 egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut cfg.bsp_tree_path_color,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 );
             });
             ui.horizontal(|ui| {
@@ -602,7 +602,7 @@ fn draw_config_window(
                 egui::color_picker::color_edit_button_srgba(
                     ui,
                     &mut cfg.bsp_tree_selected_color,
-                    egui::color_picker::Alpha::Opaque,
+                    egui::color_picker::Alpha::OnlyBlend,
                 );
             });
 


### PR DESCRIPTION
## Summary
- Allow editing alpha channel for highlight, marker, arrow, ambient, and BSP tree colors so transparency is preserved

## Testing
- `cargo test`
- `cargo fmt --all -- --check` *(fails: reports formatting diffs in src/bsp.rs and src/input.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b2274f435c832fad5fc683add56e0c

## Summary by Sourcery

Allow users to adjust the alpha channel of various UI colors by switching the egui color pickers from opaque to blend mode

Enhancements:
- Enable transparency editing for highlight color in the configuration window
- Enable transparency editing for marker color in the configuration window
- Enable transparency editing for arrow color in the configuration window
- Enable transparency editing for ambient color in the configuration window
- Enable transparency editing for BSP tree path and selection colors in the configuration window