### PR TITLE
Use lighting-aware materials for mesh rendering

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -395,7 +395,7 @@ pub fn collect_triangles_in_subtree(node: &BspNode, triangles: &mut Vec<Triangle
 }
 
 // Funkce pro vytvoření zvýrazněného meshe
-pub fn create_highlight_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
+pub fn create_highlight_mesh(triangles: &[Triangle], context: &Context) -> Gm<Mesh, PhysicalMaterial> {
     let positions: Vec<Vec3> = triangles
         .iter()
         .flat_map(|tri| {
@@ -421,7 +421,7 @@ pub fn create_highlight_mesh(triangles: &[Triangle], context: &Context) -> Gm<Me
     };
 
     let highlight_color = CONFIG.lock().unwrap().highlight_color;
-    let material = ColorMaterial::new_transparent(
+    let material = PhysicalMaterial::new_transparent(
         context,
         &CpuMaterial {
             albedo: highlight_color,
@@ -437,7 +437,7 @@ pub fn create_plane_mesh(
     plane: &Plane,
     bounds: &BoundingBox,
     context: &Context,
-) -> Gm<Mesh, ColorMaterial> {
+) -> Gm<Mesh, PhysicalMaterial> {
     // Vypočítáme střed obalového objemu
     let center = (bounds.min + bounds.max) * 0.5;
 
@@ -484,7 +484,7 @@ pub fn create_plane_mesh(
     };
 
     let plane_color = CONFIG.lock().unwrap().splitting_plane_color;
-    let material = ColorMaterial::new_transparent(
+    let material = PhysicalMaterial::new_transparent(
         context,
         &CpuMaterial {
             albedo: plane_color,

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,7 +344,7 @@ fn process_primitive(
 
 // Funkce pro vytvoření meshe z viditelných trojúhelníků
 #[allow(dead_code)]
-fn create_visible_mesh_old(triangles: &[Triangle], context: &Context) -> Gm<Mesh, ColorMaterial> {
+fn create_visible_mesh_old(triangles: &[Triangle], context: &Context) -> Gm<Mesh, PhysicalMaterial> {
     // Paralelní zpracování pozic a indexů
     let triangles_count = triangles.len();
 
@@ -386,9 +386,9 @@ fn create_visible_mesh_old(triangles: &[Triangle], context: &Context) -> Gm<Mesh
         ..Default::default()
     };
     let material = if model_color.a < 255 {
-        ColorMaterial::new_transparent(context, &cpu_material)
+        PhysicalMaterial::new_transparent(context, &cpu_material)
     } else {
-        ColorMaterial::new_opaque(context, &cpu_material)
+        PhysicalMaterial::new_opaque(context, &cpu_material)
     };
 
     Gm::new(Mesh::new(context, &visible_mesh), material)
@@ -398,7 +398,7 @@ fn create_visible_mesh(
     triangles: &[Triangle],
     context: &Context,
     texture: Option<&Texture2DRef>,
-) -> Gm<Mesh, ColorMaterial> {
+) -> Gm<Mesh, PhysicalMaterial> {
     let triangles_count = triangles.len();
     let mut positions = vec![vec3(0.0, 0.0, 0.0); triangles_count * 3];
     let mut uvs = vec![vec2(0.0, 0.0); triangles_count * 3];
@@ -441,11 +441,12 @@ fn create_visible_mesh(
     } else {
         RenderStates::default()
     };
-    let material = ColorMaterial {
-        color: model_color,
-        texture: texture.cloned(),
+    let material = PhysicalMaterial {
+        albedo: model_color,
+        albedo_texture: texture.cloned(),
         render_states,
         is_transparent,
+        ..Default::default()
     };
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }


### PR DESCRIPTION
## Summary
- Replace ColorMaterial with PhysicalMaterial in mesh creation for lighting support
- Update BSP helper meshes to use PhysicalMaterial
- Ensure ambient light continues to influence rendering

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b33aac5b84832fa0138519127ea617

## Summary by Sourcery

Enhancements:
- Replace ColorMaterial with PhysicalMaterial in visible, highlight, and plane mesh creation functions to enable lighting effects