### PR TITLE
Fix BSP tree marker to follow pointer movement

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -102,7 +102,7 @@ fn draw_bsp_tree_window(
                 plot_ui.pointer_coordinate()
             });
 
-            if plot_resp.response.clicked() {
+            if plot_resp.response.hovered() {
                 if let Some(pointer) = plot_resp.inner {
                     let mut best = None;
                     let mut best_dist = f64::INFINITY;


### PR DESCRIPTION
## Summary
- update BSP tree selection logic to react to pointer hover instead of only clicks, making marker move with cursor

## Testing
- `cargo test`
- `rustfmt --edition 2021 --check src/gui.rs`


------
https://chatgpt.com/codex/tasks/task_e_68b3434e5098832f8ec455caa965439f

## Summary by Sourcery

Enhancements:
- Change BSP tree marker to follow cursor movement by using pointer hover detection instead of click events