### PR TITLE
Fix BSP tree hover and spectator marker alignment

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -102,7 +102,7 @@ fn draw_bsp_tree_window(
                 plot_ui.pointer_coordinate()
             });
 
-            if plot_resp.response.clicked() {
+            if plot_resp.response.hovered() {
                 if let Some(pointer) = plot_resp.inner {
                     let mut best = None;
                     let mut best_dist = f64::INFINITY;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1122,6 +1122,14 @@ fn main() -> Result<()> {
 
             // Když jsme v third person mode, zobrazíme směrovou šipku pro spectator kameru
             if show_spectator_marker {
+                spectator_glow.set_transformation(
+                    Mat4::from_translation(vec3(
+                        spectator_state.pos.x,
+                        spectator_state.pos.y,
+                        spectator_state.pos.z,
+                    )) * Mat4::from_scale(cfg.camera_marker_scale),
+                );
+
                 let dir = Vector3::new(
                     spectator_state.yaw.cos() * spectator_state.pitch.cos(),
                     spectator_state.pitch.sin(),


### PR DESCRIPTION
## Summary
- update BSP tree selection logic to react to pointer hover instead of only clicks, making marker move with cursor
- ensure spectator marker sphere updates its position when showing the direction arrow

## Testing
- `cargo test`
- `rustfmt --edition 2021 --config skip_children=true --check src/main.rs`


------
https://chatgpt.com/codex/tasks/task_e_68b3434e5098832f8ec455caa965439f

## Summary by Sourcery

Make BSP tree selection respond to pointer hover and keep spectator marker aligned when showing the direction arrow

Bug Fixes:
- Update BSP tree selection logic to react on hover instead of click so the marker follows the cursor
- Ensure the spectator marker sphere’s transformation is updated each frame when the direction arrow is displayed