### PR TITLE
Add spectator marker config option and restore click selection

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,4 @@
-use crate::config::CONFIG;
+use crate::config::{Config, CONFIG};
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
@@ -405,7 +405,6 @@ pub fn draw_left_panel(
                 "Vzdálenost mezi kamerami: {:.1}",
                 (spectator_state.pos - third_person_state.pos).magnitude()
             ));
-            ui.checkbox(show_spectator_marker, "Zobrazit pozici a směr spectatoru");
 
             if let Ok(msg) = rx.try_recv() {
                 match msg {
@@ -442,6 +441,7 @@ pub fn draw_left_panel(
             spectator_state,
             third_person_state,
             mode,
+            show_spectator_marker,
             config_window_open,
         );
     }
@@ -473,6 +473,7 @@ fn draw_config_window(
     spectator_state: &mut crate::camera::CameraState,
     third_person_state: &mut crate::camera::CameraState,
     mode: crate::camera::CamMode,
+    show_spectator_marker: &mut bool,
     open: &mut bool,
 ) {
     egui::Window::new("Config")
@@ -480,6 +481,23 @@ fn draw_config_window(
         .vscroll(true)
         .show(ctx, |ui| {
             let mut cfg = CONFIG.lock().unwrap();
+
+            if ui.button("Load default").clicked() {
+                let defaults = Config::default();
+                cam.speed = defaults.camera_speed;
+                cam.look_speed = defaults.look_speed;
+                spectator_state.pos = defaults.default_spectator_pos;
+                third_person_state.pos = defaults.default_third_person_pos;
+                if mode == crate::camera::CamMode::Spectator {
+                    cam.pos = spectator_state.pos;
+                } else if mode == crate::camera::CamMode::ThirdPerson {
+                    cam.pos = third_person_state.pos;
+                }
+                *show_spectator_marker = false;
+                *cfg = defaults;
+            }
+
+            ui.checkbox(show_spectator_marker, "Zobrazit pozici a směr spectatoru");
 
             ui.heading("Colors & Lighting");
             ui.horizontal(|ui| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1122,6 +1122,14 @@ fn main() -> Result<()> {
 
             // Když jsme v third person mode, zobrazíme směrovou šipku pro spectator kameru
             if show_spectator_marker {
+                spectator_glow.set_transformation(
+                    Mat4::from_translation(vec3(
+                        spectator_state.pos.x,
+                        spectator_state.pos.y,
+                        spectator_state.pos.z,
+                    )) * Mat4::from_scale(cfg.camera_marker_scale),
+                );
+
                 let dir = Vector3::new(
                     spectator_state.yaw.cos() * spectator_state.pitch.cos(),
                     spectator_state.pitch.sin(),


### PR DESCRIPTION
## Summary
- move spectator position/arrow toggle into config window and add a Load default reset
- select BSP tree nodes by clicking instead of hovering

## Testing
- `cargo test`
- `rustfmt --edition 2021 --check src/gui.rs`


------
https://chatgpt.com/codex/tasks/task_e_68b3434e5098832f8ec455caa965439f

## Summary by Sourcery

Introduce a configurable spectator marker toggle, add a ‘Load default’ reset button in the config window, move the spectator marker control into settings, and revert BSP tree node selection to click-based interaction.

New Features:
- Add ‘Load default’ button in the config window to reset camera and spectator settings.
- Add show_spectator_marker config option to toggle spectator marker visibility.

Bug Fixes:
- Restore BSP tree node selection by clicking instead of hovering.

Enhancements:
- Move spectator marker checkbox from the main panel into the config window.