### PR TITLE
Add spectator marker config option and view angle controls

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -4,15 +4,14 @@ Quick index of key functions and methods in the project. Each entry links to the
 source code so you can jump directly to the implementation.
 
 ## `src/camera.rs`
-- [`FreeCamera::new`](src/camera.rs#L22-L29) – initialize a free camera with
+- [`FreeCamera::new`](src/camera.rs#L20-L29) – initialize a free camera with
   default parameters.
-- [`FreeCamera::update_smooth`](src/camera.rs#L45-L71) – update position and
+- [`FreeCamera::update_smooth`](src/camera.rs#L44-L72) – update position and
   orientation based on keyboard input.
-- [`FreeCamera::cam`](src/camera.rs#L73-L83) – construct a `three_d` camera from
+- [`FreeCamera::cam`](src/camera.rs#L75-L86) – construct a `three_d` camera from
   the current state.
-- [`SwitchDelay::can_switch`](src/camera.rs#L101-L103) – check if camera mode
-  can be toggled.
-- [`CameraState::new`](src/camera.rs#L117-L120) – snapshot of camera parameters.
+- [`CameraState::new`](src/camera.rs#L104-L107) – create a camera state from
+  position and orientation.
 
 ## `src/bsp.rs`
 - [`build_bsp`](src/bsp.rs#L293-L331) – construct the BSP tree and assign node
@@ -48,7 +47,7 @@ source code so you can jump directly to the implementation.
   tilt from arrow keys.
 
 ## `src/main.rs`
-- [`load_cpu_mesh`](src/main.rs#L61-L109) – load a GLTF/GLB file into a CPU
+- [`load_cpu_mesh`](src/main.rs#L58-L106) – load a GLTF/GLB file into a CPU
   mesh and optional texture with basic validation.
-- [`load_gltf_with_gltf_crate`](src/main.rs#L111-L168) – helper using the
+- [`load_gltf_with_gltf_crate`](src/main.rs#L108-L169) – helper using the
   `gltf` crate to parse meshes and textures.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,6 @@
 use crate::config::CONFIG;
 use crate::input::{InputManager, KeyCode};
 use cgmath::{Deg, Vector3};
-use std::f32::consts::FRAC_PI_2;
 use three_d::*;
 
 #[derive(Clone)]
@@ -21,8 +20,8 @@ impl FreeCamera {
         let cfg = CONFIG.lock().unwrap().clone();
         Self {
             pos,
-            yaw: -FRAC_PI_2,
-            pitch: 0.0,
+            yaw: cfg.default_spectator_yaw,
+            pitch: cfg.default_spectator_pitch,
             speed: cfg.camera_speed,
             look_speed: cfg.look_speed,
         }
@@ -92,26 +91,6 @@ pub enum CamMode {
     ThirdPerson,
 }
 
-pub struct SwitchDelay {
-    last_switch_time: f64,
-    cooldown: f64,
-}
-
-impl SwitchDelay {
-    pub fn new(cooldown: f64) -> Self {
-        Self {
-            last_switch_time: 0.0,
-            cooldown,
-        }
-    }
-    pub fn can_switch(&self, current_time: f64) -> bool {
-        current_time - self.last_switch_time >= self.cooldown
-    }
-    pub fn record_switch(&mut self, current_time: f64) {
-        self.last_switch_time = current_time;
-    }
-}
-
 #[derive(Clone)]
 pub struct CameraState {
     pub pos: Vector3<f32>,
@@ -121,12 +100,12 @@ pub struct CameraState {
 }
 
 impl CameraState {
-    pub fn new(pos: Vector3<f32>) -> Self {
+    pub fn new(pos: Vector3<f32>, yaw: f32, pitch: f32) -> Self {
         let speed = CONFIG.lock().unwrap().camera_speed;
         Self {
             pos,
-            yaw: -FRAC_PI_2,
-            pitch: 0.0,
+            yaw,
+            pitch,
             speed,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 use cgmath::Vector3;
 use egui::Color32;
 use once_cell::sync::Lazy;
+use std::f32::consts::FRAC_PI_2;
 use std::sync::Mutex;
 use three_d::Srgba;
 
@@ -44,9 +45,12 @@ pub struct Config {
     pub default_fov_deg: f32,
     pub near_plane: f32,
     pub far_plane: f32,
-    pub camera_switch_cooldown: f64,
     pub default_spectator_pos: Vector3<f32>,
     pub default_third_person_pos: Vector3<f32>,
+    pub default_spectator_yaw: f32,
+    pub default_spectator_pitch: f32,
+    pub default_third_person_yaw: f32,
+    pub default_third_person_pitch: f32,
     pub camera_marker_scale: f32,
     pub direction_ray_thickness: f32,
     pub direction_ray_length: f32,
@@ -74,9 +78,12 @@ impl Default for Config {
             default_fov_deg: 60.0,
             near_plane: 0.1,
             far_plane: 1000.0,
-            camera_switch_cooldown: 2.0,
             default_spectator_pos: Vector3::new(0.0, 2.0, 8.0),
             default_third_person_pos: Vector3::new(5.0, 2.0, 8.0),
+            default_spectator_yaw: -FRAC_PI_2,
+            default_spectator_pitch: 0.0,
+            default_third_person_yaw: -FRAC_PI_2,
+            default_third_person_pitch: 0.0,
             camera_marker_scale: 0.2,
             direction_ray_thickness: 0.05,
             direction_ray_length: 3.0,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,4 @@
-use crate::config::CONFIG;
+use crate::config::{Config, CONFIG};
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
@@ -405,7 +405,6 @@ pub fn draw_left_panel(
                 "Vzdálenost mezi kamerami: {:.1}",
                 (spectator_state.pos - third_person_state.pos).magnitude()
             ));
-            ui.checkbox(show_spectator_marker, "Zobrazit pozici a směr spectatoru");
 
             if let Ok(msg) = rx.try_recv() {
                 match msg {
@@ -442,6 +441,7 @@ pub fn draw_left_panel(
             spectator_state,
             third_person_state,
             mode,
+            show_spectator_marker,
             config_window_open,
         );
     }
@@ -473,6 +473,7 @@ fn draw_config_window(
     spectator_state: &mut crate::camera::CameraState,
     third_person_state: &mut crate::camera::CameraState,
     mode: crate::camera::CamMode,
+    show_spectator_marker: &mut bool,
     open: &mut bool,
 ) {
     egui::Window::new("Config")
@@ -480,6 +481,29 @@ fn draw_config_window(
         .vscroll(true)
         .show(ctx, |ui| {
             let mut cfg = CONFIG.lock().unwrap();
+
+            if ui.button("Load default").clicked() {
+                let defaults = Config::default();
+                cam.speed = defaults.camera_speed;
+                cam.look_speed = defaults.look_speed;
+                spectator_state.pos = defaults.default_spectator_pos;
+                spectator_state.yaw = defaults.default_spectator_yaw;
+                spectator_state.pitch = defaults.default_spectator_pitch;
+                third_person_state.pos = defaults.default_third_person_pos;
+                third_person_state.yaw = defaults.default_third_person_yaw;
+                third_person_state.pitch = defaults.default_third_person_pitch;
+                if mode == crate::camera::CamMode::Spectator {
+                    cam.pos = spectator_state.pos;
+                    cam.yaw = spectator_state.yaw;
+                    cam.pitch = spectator_state.pitch;
+                } else if mode == crate::camera::CamMode::ThirdPerson {
+                    cam.pos = third_person_state.pos;
+                    cam.yaw = third_person_state.yaw;
+                    cam.pitch = third_person_state.pitch;
+                }
+                *show_spectator_marker = false;
+                *cfg = defaults;
+            }
 
             ui.heading("Colors & Lighting");
             ui.horizontal(|ui| {
@@ -625,10 +649,10 @@ fn draw_config_window(
             ui.add(egui::Slider::new(&mut cfg.default_fov_deg, 30.0..=120.0).text("FOV deg"));
             ui.add(egui::Slider::new(&mut cfg.near_plane, 0.01..=10.0).text("Near plane"));
             ui.add(egui::Slider::new(&mut cfg.far_plane, 10.0..=5000.0).text("Far plane"));
-            ui.add(
-                egui::Slider::new(&mut cfg.camera_switch_cooldown, 0.1..=10.0)
-                    .text("Switch cooldown"),
-            );
+
+            ui.separator();
+            ui.heading("Spectator");
+            ui.checkbox(show_spectator_marker, "Zobrazit pozici a směr spectatoru");
 
             ui.horizontal(|ui| {
                 ui.label("Spectator pos");
@@ -650,6 +674,28 @@ fn draw_config_window(
                 }
             });
             ui.horizontal(|ui| {
+                ui.label("Spectator angle");
+                let mut yaw_deg = spectator_state.yaw.to_degrees();
+                let mut pitch_deg = spectator_state.pitch.to_degrees();
+                let mut changed = false;
+                changed |= ui
+                    .add(egui::DragValue::new(&mut yaw_deg).suffix("°"))
+                    .changed();
+                changed |= ui
+                    .add(egui::DragValue::new(&mut pitch_deg).suffix("°"))
+                    .changed();
+                if changed {
+                    spectator_state.yaw = yaw_deg.to_radians();
+                    spectator_state.pitch = pitch_deg.to_radians();
+                    cfg.default_spectator_yaw = spectator_state.yaw;
+                    cfg.default_spectator_pitch = spectator_state.pitch;
+                    if mode == crate::camera::CamMode::Spectator {
+                        cam.yaw = spectator_state.yaw;
+                        cam.pitch = spectator_state.pitch;
+                    }
+                }
+            });
+            ui.horizontal(|ui| {
                 ui.label("Third person pos");
                 let mut changed = false;
                 changed |= ui
@@ -665,6 +711,28 @@ fn draw_config_window(
                     cfg.default_third_person_pos = third_person_state.pos;
                     if mode == crate::camera::CamMode::ThirdPerson {
                         cam.pos = third_person_state.pos;
+                    }
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Third person angle");
+                let mut yaw_deg = third_person_state.yaw.to_degrees();
+                let mut pitch_deg = third_person_state.pitch.to_degrees();
+                let mut changed = false;
+                changed |= ui
+                    .add(egui::DragValue::new(&mut yaw_deg).suffix("°"))
+                    .changed();
+                changed |= ui
+                    .add(egui::DragValue::new(&mut pitch_deg).suffix("°"))
+                    .changed();
+                if changed {
+                    third_person_state.yaw = yaw_deg.to_radians();
+                    third_person_state.pitch = pitch_deg.to_radians();
+                    cfg.default_third_person_yaw = third_person_state.yaw;
+                    cfg.default_third_person_pitch = third_person_state.pitch;
+                    if mode == crate::camera::CamMode::ThirdPerson {
+                        cam.yaw = third_person_state.yaw;
+                        cam.pitch = third_person_state.pitch;
                     }
                 }
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use crate::bsp::{
     create_plane_mesh, find_deepest_node_containing_point, find_node, traverse_bsp_with_frustum,
     triangle_center, BspNode, BspStats, Frustum, Triangle,
 };
-use crate::camera::{CamMode, CameraState, FreeCamera, SwitchDelay};
+use crate::camera::{CamMode, CameraState, FreeCamera};
 use crate::config::CONFIG;
 use crate::input::{InputManager, KeyCode};
 
@@ -617,7 +617,11 @@ fn main() -> Result<()> {
     // před inicializací kamery přidáme mutable proměnné pro stavy kamer obou režimů
     let mut cam = FreeCamera::new(cfg.default_spectator_pos);
     let mut spectator_state = CameraState::from_camera(&cam);
-    let mut third_person_state = CameraState::new(cfg.default_third_person_pos); // Jiná pozice pro lepší vizualizaci
+    let mut third_person_state = CameraState::new(
+        cfg.default_third_person_pos,
+        cfg.default_third_person_yaw,
+        cfg.default_third_person_pitch,
+    ); // Jiná pozice pro lepší vizualizaci
     let mut mode = CamMode::Spectator;
 
     // Proměnná pro zobrazení značky spectator kamery
@@ -642,9 +646,6 @@ fn main() -> Result<()> {
 
     // Inicializace InputManageru pro plynulé ovládání s více klávesami
     let mut input_manager = InputManager::new();
-
-    // Přidání struktury pro sledování času přepnutí režimu
-    let mut switch_delay = SwitchDelay::new(cfg.camera_switch_cooldown); // cooldown mezi přepnutími
 
     // ----------------------------------------------------------------------------
     // Stav pro interaktivní výběr BSP:
@@ -948,11 +949,10 @@ fn main() -> Result<()> {
 
         // --- ovládání ---
         // --- ovládání přepnutí režimu pomocí kláves F a G ---
-        let current_time = frame_input.accumulated_time;
 
         // Pomocná funkce pro přepínání režimů
         let mut switch_camera_mode = |target_mode: CamMode| {
-            if switch_delay.can_switch(current_time) && mode != target_mode {
+            if mode != target_mode {
                 match target_mode {
                     CamMode::Spectator => {
                         // Ulož aktuální pozici do ThirdPerson stavu
@@ -975,9 +975,6 @@ fn main() -> Result<()> {
                         println!("Přepnuto na režim: ThirdPerson");
                     }
                 }
-
-                // Zaznamenej čas posledního přepnutí
-                switch_delay.record_switch(current_time);
 
                 // Aktualizuj pozice glow značek
                 spectator_glow.set_transformation(
@@ -1027,14 +1024,22 @@ fn main() -> Result<()> {
         if input_manager.is_key_pressed(KeyCode::Home) {
             if mode == CamMode::Spectator {
                 // Vytvoření nového stavu kamery s výchozí pozicí, ale aktuální rychlostí kamery
-                let mut reset_state = CameraState::new(cfg.default_spectator_pos);
+                let mut reset_state = CameraState::new(
+                    cfg.default_spectator_pos,
+                    cfg.default_spectator_yaw,
+                    cfg.default_spectator_pitch,
+                );
                 reset_state.speed = cam.speed; // Zachová aktuální rychlost
                 reset_state.apply_to_camera(&mut cam);
                 println!("Kamera resetována na výchozí spectator pozici");
             } else {
                 // ThirdPerson
                 // Vytvoření nového stavu kamery s výchozí pozicí, ale aktuální rychlostí kamery
-                let mut reset_state = CameraState::new(cfg.default_third_person_pos);
+                let mut reset_state = CameraState::new(
+                    cfg.default_third_person_pos,
+                    cfg.default_third_person_yaw,
+                    cfg.default_third_person_pitch,
+                );
                 reset_state.speed = cam.speed; // Zachová aktuální rychlost
                 reset_state.apply_to_camera(&mut cam);
                 println!("Kamera resetována na výchozí third person pozici");
@@ -1122,6 +1127,14 @@ fn main() -> Result<()> {
 
             // Když jsme v third person mode, zobrazíme směrovou šipku pro spectator kameru
             if show_spectator_marker {
+                spectator_glow.set_transformation(
+                    Mat4::from_translation(vec3(
+                        spectator_state.pos.x,
+                        spectator_state.pos.y,
+                        spectator_state.pos.z,
+                    )) * Mat4::from_scale(cfg.camera_marker_scale),
+                );
+
                 let dir = Vector3::new(
                     spectator_state.yaw.cos() * spectator_state.pitch.cos(),
                     spectator_state.pitch.sin(),


### PR DESCRIPTION
## Summary
- move spectator position/arrow toggle into config window and add a Load default reset
- select BSP tree nodes by clicking instead of hovering
- keep spectator marker aligned with the arrow and follow the cursor
- group spectator controls under a Spectator section and remove the camera switch cooldown
- allow adjusting camera yaw/pitch in the config window with saved defaults

## Testing
- `cargo test`
- `rustfmt --edition 2021 --check src/config.rs src/camera.rs src/gui.rs`
- `rustfmt --edition 2021 --config skip_children=true --check src/main.rs`


------
https://chatgpt.com/codex/tasks/task_e_68b3434e5098832f8ec455caa965439f

## Summary by Sourcery

Add and reorganize spectator and camera view controls in the config window, enable resetting to defaults, remove camera switch cooldown, and refactor camera state initialization to include yaw and pitch defaults

New Features:
- Add "Load default" button in config window to reset camera speeds, positions, and angles to defaults
- Expose a Spectator section in the config window with a toggle for displaying the spectator marker
- Add sliders in the config window for adjusting spectator and third-person camera yaw and pitch, with persistent defaults
- Update spectator marker transformation to align with camera direction and follow the cursor in third-person mode

Enhancements:
- Remove the camera switch cooldown mechanism and the related SwitchDelay struct and config field
- Initialize FreeCamera and CameraState with default yaw and pitch values from the configuration

Documentation:
- Update FUNCTIONS.md references to match revised signatures and default parameters