### PR TITLE
Fix texture replacement and test module annotation

### DIFF
--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -704,8 +704,6 @@ pub fn traverse_bsp_with_frustum(
     }
 }
 
-#[derive(Clone, Debug)]
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gui/left_panel.rs
+++ b/src/gui/left_panel.rs
@@ -1,6 +1,7 @@
 use crate::config::CONFIG;
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
+use log::error;
 use std::sync::atomic::AtomicUsize;
 use three_d::{CpuTexture, Texture2DRef};
 
@@ -73,9 +74,21 @@ pub fn draw_left_panel(
                     .add_filter("Image", &["png", "jpg", "jpeg"])
                     .pick_file()
                 {
-                    if let Ok(tex) = three_d_asset::io::load_and_deserialize::<CpuTexture>(&path) {
-                        *current_texture = Some(Texture2DRef::from_cpu_texture(gl, &tex));
-                        *show_texture = true;
+                    match three_d_asset::io::load_and_deserialize::<CpuTexture>(&path) {
+                        Ok(tex) => {
+                            // Drop the previous texture (if any) so the new one is always used
+                            *current_texture = None;
+                            *current_texture =
+                                Some(Texture2DRef::from_cpu_texture(gl, &tex));
+                            *show_texture = true;
+                        }
+                        Err(e) => {
+                            error!(
+                                "Failed to load texture {}: {}",
+                                path.display(),
+                                e
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Ensure choosing a new image replaces the previous texture and log loading errors
- Remove erroneous `derive` attribute from test module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b35e42a418832fa162ab5e3b1a8dc4

## Summary by Sourcery

Fix texture loading behavior to replace previous texture and log errors, and remove an erroneous derive attribute from the BSP test module

Bug Fixes:
- Drop and replace the previous texture when a new image is selected
- Log errors if texture loading fails instead of silently ignoring them
- Remove the incorrect derive attribute from the BSP test module