### PR TITLE
Fix texture replacement and enable JPEG support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,7 @@ checksum = "95c40cd76bbe3751f6a286dd09c9971766d37b3a9c222e926f622d098bdcc424"
 dependencies = [
  "cgmath",
  "half",
+ "image",
  "thiserror 2.0.12",
  "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow          = "1"
 cgmath          = "0.18"
 egui            = "0.29"
 three-d         = { version = "0.18", features = ["window", "egui-gui"] }
-three-d-asset   = "0.9"
+three-d-asset   = { version = "0.9", features = ["png", "jpeg"] }
 rfd             = { version = "0.9", default-features = false, features = ["xdg-portal"] }
 gltf            = { version = "1.4", features = ["extras", "names"] }
 rayon           = "1.10.0"

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -704,8 +704,6 @@ pub fn traverse_bsp_with_frustum(
     }
 }
 
-#[derive(Clone, Debug)]
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gui/left_panel.rs
+++ b/src/gui/left_panel.rs
@@ -1,6 +1,7 @@
 use crate::config::CONFIG;
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};
+use log::error;
 use std::sync::atomic::AtomicUsize;
 use three_d::{CpuTexture, Texture2DRef};
 
@@ -73,9 +74,21 @@ pub fn draw_left_panel(
                     .add_filter("Image", &["png", "jpg", "jpeg"])
                     .pick_file()
                 {
-                    if let Ok(tex) = three_d_asset::io::load_and_deserialize::<CpuTexture>(&path) {
-                        *current_texture = Some(Texture2DRef::from_cpu_texture(gl, &tex));
-                        *show_texture = true;
+                    match three_d_asset::io::load_and_deserialize::<CpuTexture>(&path) {
+                        Ok(tex) => {
+                            // Drop the previous texture (if any) so the new one is always used
+                            *current_texture = None;
+                            *current_texture =
+                                Some(Texture2DRef::from_cpu_texture(gl, &tex));
+                            *show_texture = true;
+                        }
+                        Err(e) => {
+                            error!(
+                                "Failed to load texture {}: {}",
+                                path.display(),
+                                e
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Drop the previous texture when loading a new one and log any load failures
- Enable JPEG and PNG features for `three-d-asset`
- Remove erroneous `derive` attribute from the BSP test module

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b35e42a418832fa162ab5e3b1a8dc4

## Summary by Sourcery

Enhance texture loading by dropping old textures and logging errors, enable JPEG and PNG support in asset loading, and clean up BSP tests.

New Features:
- Enable JPEG and PNG support for three-d-asset

Bug Fixes:
- Drop previous texture when loading a new one to ensure the new texture is always used
- Log failures when loading textures

Enhancements:
- Remove erroneous derive attribute from the BSP test module