### PR TITLE
docs: add project overview and module guides

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -4,50 +4,65 @@ Quick index of key functions and methods in the project. Each entry links to the
 source code so you can jump directly to the implementation.
 
 ## `src/camera.rs`
-- [`FreeCamera::new`](src/camera.rs#L20-L29) – initialize a free camera with
+- [`FreeCamera::new`](src/camera.rs#L19-L27) – initialize a free camera with
   default parameters.
-- [`FreeCamera::update_smooth`](src/camera.rs#L44-L72) – update position and
+- [`FreeCamera::update_smooth`](src/camera.rs#L43-L72) – update position and
   orientation based on keyboard input.
-- [`FreeCamera::cam`](src/camera.rs#L75-L86) – construct a `three_d` camera from
+- [`FreeCamera::cam`](src/camera.rs#L74-L85) – construct a `three_d` camera from
   the current state.
-- [`CameraState::new`](src/camera.rs#L104-L107) – create a camera state from
+- [`CameraState::new`](src/camera.rs#L103-L111) – create a camera state from
   position and orientation.
 
 ## `src/bsp.rs`
-- [`build_bsp`](src/bsp.rs#L293-L331) – construct the BSP tree and assign node
+- [`build_bsp`](src/bsp.rs#L250-L289) – construct the BSP tree and assign node
   IDs.
-- [`find_node`](src/bsp.rs#L334-L342) – locate a node by its identifier.
-- [`find_node_path`](src/bsp.rs#L344-L367) – collect the path from root to a
+- [`find_node`](src/bsp.rs#L292-L300) – locate a node by its identifier.
+- [`find_node_path`](src/bsp.rs#L304-L325) – collect the path from root to a
   specific node.
-- [`find_deepest_node_containing_point`](src/bsp.rs#L369-L389) – find the deepest
+- [`find_deepest_node_containing_point`](src/bsp.rs#L327-L347) – find the deepest
   node that contains a given point.
-- [`collect_triangles_in_subtree`](src/bsp.rs#L382-L395) – gather triangles from
+- [`collect_triangles_in_subtree`](src/bsp.rs#L350-L360) – gather triangles from
   a subtree.
-- [`create_highlight_mesh`](src/bsp.rs#L397-L433) – build a colored mesh for the
+- [`create_highlight_mesh`](src/bsp.rs#L365-L403) – build a colored mesh for the
   selected triangles.
-- [`create_plane_mesh`](src/bsp.rs#L435-L495) – generate a mesh representing the
+- [`create_plane_mesh`](src/bsp.rs#L406-L466) – generate a mesh representing the
   splitting plane of a node.
-- [`cpu_mesh_to_triangles`](src/bsp.rs#L498-L589) – convert a `CpuMesh` to a
+- [`cpu_mesh_to_triangles`](src/bsp.rs#L469-L559) – convert a `CpuMesh` to a
   triangle list.
-- [`traverse_bsp_with_frustum`](src/bsp.rs#L592-L745) – traverse the BSP tree
+- [`traverse_bsp_with_frustum`](src/bsp.rs#L562-L774) – traverse the BSP tree
   while performing frustum culling.
+ 
+## `src/geometry.rs`
+- [`BoundingBox::from_triangles`](src/geometry.rs#L81-L98) – build an axis-aligned bounding box for a list of triangles.
+- [`Frustum::from_camera`](src/geometry.rs#L138-L175) – extract six clipping planes from a `three_d` camera.
+- [`triangle_center`](src/geometry.rs#L182-L184) – compute the centroid of a triangle.
 
-## `src/gui.rs`
-- [`layout_bsp_tree`](src/gui.rs#L13-L35) – compute plot positions for BSP
-  nodes.
-- [`draw_left_panel`](src.gui.rs#L119-L143) – render the left control panel and
-  handle UI interactions.
+## `src/gui/left_panel.rs`
+- [`draw_left_panel`](src/gui/left_panel.rs#L14-L490) – render the left control panel and handle UI interactions.
+
+## `src/gui/tree.rs`
+- [`layout_bsp_tree`](src/gui/tree.rs#L14-L33) – compute plot positions for BSP nodes.
+- [`draw_bsp_tree_window`](src/gui/tree.rs#L35-L113) – show an interactive BSP tree view.
+
+## `src/gui/config.rs`
+- [`draw_config_window`](src/gui/config.rs#L8-L302) – runtime configuration UI for colors and camera settings.
 
 ## `src/input.rs`
-- [`InputManager::update_key_states`](src/input.rs#L76-L90) – update internal
+- [`InputManager::update_key_states`](src/input.rs#L78-L92) – update internal
   key state map from event list.
-- [`InputManager::get_movement_vector`](src/input.rs#L98-L126) – translate key
+- [`InputManager::get_movement_vector`](src/input.rs#L100-L129) – translate key
   presses into a normalized movement vector.
-- [`InputManager::get_tilt_value`](src/input.rs#L129-L139) – compute horizontal
+- [`InputManager::get_tilt_value`](src/input.rs#L131-L142) – compute horizontal
   tilt from arrow keys.
 
-## `src/main.rs`
-- [`load_cpu_mesh`](src/main.rs#L58-L106) – load a GLTF/GLB file into a CPU
-  mesh and optional texture with basic validation.
-- [`load_gltf_with_gltf_crate`](src/main.rs#L108-L169) – helper using the
-  `gltf` crate to parse meshes and textures.
+## `src/loader.rs`
+- [`load_cpu_mesh`](src/loader.rs#L8-L55) – load a GLTF/GLB file with basic validation and logging.
+- [`load_gltf_with_gltf_crate`](src/loader.rs#L57-L113) – helper using the `gltf` crate to parse meshes and textures.
+
+## `src/config.rs`
+- [`Config`](src/config.rs#L13-L64) – collection of runtime configuration options.
+- [`CONFIG`](src/config.rs#L102-L103) – global mutable configuration store.
+
+## `src/lang.rs`
+- [`Language`](src/lang.rs#L3-L7) – supported UI languages.
+- [`tr`](src/lang.rs#L9-L14) – translate a pair of strings based on selected language.

--- a/README.md
+++ b/README.md
@@ -60,4 +60,19 @@ and lighting can be customized by editing the constants in this file, e.g.:
 - `AMBIENT_LIGHT_INTENSITY` and `AMBIENT_LIGHT_COLOR` – ambient light settings.
 - `DEFAULT_FOV_DEG` – default field of view for the camera.
 - `camera_speed` and `look_speed` – movement speed and turning sensitivity.
+ 
+## Code Overview
 
+The project is split into a few small Rust modules:
+
+- [`bsp.rs`](src/bsp.rs) – builds and traverses the binary space partition tree used for culling and highlighting.
+- [`geometry.rs`](src/geometry.rs) – triangle, plane and bounding box types with helper math routines.
+- [`camera.rs`](src/camera.rs) – free‑flying camera with smooth keyboard controls.
+- [`input.rs`](src/input.rs) – thin wrapper translating keyboard events into movement vectors.
+- [`gui/`](src/gui) – `egui` panels for loading models, tweaking settings and visualising the BSP tree.
+- [`loader.rs`](src/loader.rs) – GLTF/GLB mesh loader with basic sanity checks.
+- [`config.rs`](src/config.rs) – centralized store of user‑tunable parameters.
+- [`lang.rs`](src/lang.rs) – minimal English/Czech translation helper.
+- [`main.rs`](src/main.rs) – application entry point tying everything together.
+
+For a per‑function index see [FUNCTIONS.md](FUNCTIONS.md).

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// BSP and geometry utilities
+//! Core BSP tree construction, traversal and visualization utilities.
 use cgmath::{Vector2, Vector3};
 use rayon::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Camera utilities
+//! Free‑flight and third‑person camera utilities.
 
 use crate::config::CONFIG;
 use crate::input::{InputManager, KeyCode};

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,3 +1,5 @@
+//! Basic geometric primitives and helpers used throughout the viewer.
+
 use cgmath::{InnerSpace, Vector2, Vector3};
 use three_d::Camera;
 
@@ -112,9 +114,21 @@ impl BoundingBox {
 
     pub fn intersects_plane(&self, plane: &Plane) -> bool {
         let p = Vector3::new(
-            if plane.n.x >= 0.0 { self.max.x } else { self.min.x },
-            if plane.n.y >= 0.0 { self.max.y } else { self.min.y },
-            if plane.n.z >= 0.0 { self.max.z } else { self.min.z },
+            if plane.n.x >= 0.0 {
+                self.max.x
+            } else {
+                self.min.x
+            },
+            if plane.n.y >= 0.0 {
+                self.max.y
+            } else {
+                self.min.y
+            },
+            if plane.n.z >= 0.0 {
+                self.max.z
+            } else {
+                self.min.z
+            },
         );
         plane.side(p) >= 0.0
     }
@@ -136,35 +150,53 @@ impl Frustum {
     pub fn from_camera(camera: &Camera) -> Self {
         let vp_matrix = camera.projection() * camera.view();
         let mat = [
-            vp_matrix.x.x, vp_matrix.x.y, vp_matrix.x.z, vp_matrix.x.w,
-            vp_matrix.y.x, vp_matrix.y.y, vp_matrix.y.z, vp_matrix.y.w,
-            vp_matrix.z.x, vp_matrix.z.y, vp_matrix.z.z, vp_matrix.z.w,
-            vp_matrix.w.x, vp_matrix.w.y, vp_matrix.w.z, vp_matrix.w.w,
+            vp_matrix.x.x,
+            vp_matrix.x.y,
+            vp_matrix.x.z,
+            vp_matrix.x.w,
+            vp_matrix.y.x,
+            vp_matrix.y.y,
+            vp_matrix.y.z,
+            vp_matrix.y.w,
+            vp_matrix.z.x,
+            vp_matrix.z.y,
+            vp_matrix.z.z,
+            vp_matrix.z.w,
+            vp_matrix.w.x,
+            vp_matrix.w.y,
+            vp_matrix.w.z,
+            vp_matrix.w.w,
         ];
 
         let left = Plane {
             n: Vector3::new(mat[3] + mat[0], mat[7] + mat[4], mat[11] + mat[8]).normalize(),
-            d: (mat[15] + mat[12]) / (mat[3] + mat[0]).hypot((mat[7] + mat[4]).hypot(mat[11] + mat[8])),
+            d: (mat[15] + mat[12])
+                / (mat[3] + mat[0]).hypot((mat[7] + mat[4]).hypot(mat[11] + mat[8])),
         };
         let right = Plane {
             n: Vector3::new(mat[3] - mat[0], mat[7] - mat[4], mat[11] - mat[8]).normalize(),
-            d: (mat[15] - mat[12]) / (mat[3] - mat[0]).hypot((mat[7] - mat[4]).hypot(mat[11] - mat[8])),
+            d: (mat[15] - mat[12])
+                / (mat[3] - mat[0]).hypot((mat[7] - mat[4]).hypot(mat[11] - mat[8])),
         };
         let bottom = Plane {
             n: Vector3::new(mat[3] + mat[1], mat[7] + mat[5], mat[11] + mat[9]).normalize(),
-            d: (mat[15] + mat[13]) / (mat[3] + mat[1]).hypot((mat[7] + mat[5]).hypot(mat[11] + mat[9])),
+            d: (mat[15] + mat[13])
+                / (mat[3] + mat[1]).hypot((mat[7] + mat[5]).hypot(mat[11] + mat[9])),
         };
         let top = Plane {
             n: Vector3::new(mat[3] - mat[1], mat[7] - mat[5], mat[11] - mat[9]).normalize(),
-            d: (mat[15] - mat[13]) / (mat[3] - mat[1]).hypot((mat[7] - mat[5]).hypot(mat[11] - mat[9])),
+            d: (mat[15] - mat[13])
+                / (mat[3] - mat[1]).hypot((mat[7] - mat[5]).hypot(mat[11] - mat[9])),
         };
         let near = Plane {
             n: Vector3::new(mat[3] + mat[2], mat[7] + mat[6], mat[11] + mat[10]).normalize(),
-            d: (mat[15] + mat[14]) / (mat[3] + mat[2]).hypot((mat[7] + mat[6]).hypot(mat[11] + mat[10])),
+            d: (mat[15] + mat[14])
+                / (mat[3] + mat[2]).hypot((mat[7] + mat[6]).hypot(mat[11] + mat[10])),
         };
         let far = Plane {
             n: Vector3::new(mat[3] - mat[2], mat[7] - mat[6], mat[11] - mat[10]).normalize(),
-            d: (mat[15] - mat[14]) / (mat[3] - mat[2]).hypot((mat[7] - mat[6]).hypot(mat[11] - mat[10])),
+            d: (mat[15] - mat[14])
+                / (mat[3] - mat[2]).hypot((mat[7] - mat[6]).hypot(mat[11] - mat[10])),
         };
 
         Self {

--- a/src/gui/config.rs
+++ b/src/gui/config.rs
@@ -1,7 +1,9 @@
+//! Runtime configuration window allowing tweaks to colors and camera settings.
+
 use crate::config::{Config, CONFIG};
 use three_d::Srgba;
 
-use crate::lang::{Language, tr};
+use crate::lang::{tr, Language};
 
 pub fn draw_config_window(
     ctx: &egui::Context,
@@ -33,7 +35,10 @@ pub fn draw_config_window(
                     });
             });
 
-            if ui.button(tr(lang, "Load default", "Načíst výchozí")).clicked() {
+            if ui
+                .button(tr(lang, "Load default", "Načíst výchozí"))
+                .clicked()
+            {
                 let defaults = Config::default();
                 cam.speed = defaults.camera_speed;
                 cam.look_speed = defaults.look_speed;
@@ -70,7 +75,10 @@ pub fn draw_config_window(
             ];
             ui.horizontal(|ui| {
                 ui.label(tr(lang, "Model", "Model"));
-                if ui.color_edit_button_srgba_unmultiplied(&mut color).changed() {
+                if ui
+                    .color_edit_button_srgba_unmultiplied(&mut color)
+                    .changed()
+                {
                     cfg.model_color = Srgba::new(color[0], color[1], color[2], color[3]);
                 }
             });
@@ -131,8 +139,11 @@ pub fn draw_config_window(
             });
 
             ui.add(
-                egui::Slider::new(&mut cfg.ambient_light_intensity, 0.0..=5.0)
-                    .text(tr(lang, "Ambient intensity", "Intenzita ambientního osvětlení")),
+                egui::Slider::new(&mut cfg.ambient_light_intensity, 0.0..=5.0).text(tr(
+                    lang,
+                    "Ambient intensity",
+                    "Intenzita ambientního osvětlení",
+                )),
             );
             let mut acol = [
                 cfg.ambient_light_color.r,
@@ -149,7 +160,13 @@ pub fn draw_config_window(
 
             ui.separator();
             ui.heading(tr(lang, "BSP Tree", "BSP Strom"));
-            ui.add(egui::Slider::new(&mut cfg.bsp_tree_text_size, 8.0..=32.0).text(tr(lang, "Text size", "Velikost textu")));
+            ui.add(
+                egui::Slider::new(&mut cfg.bsp_tree_text_size, 8.0..=32.0).text(tr(
+                    lang,
+                    "Text size",
+                    "Velikost textu",
+                )),
+            );
             ui.horizontal(|ui| {
                 ui.label(tr(lang, "Path color", "Barva cesty"));
                 egui::color_picker::color_edit_button_srgba(
@@ -169,40 +186,77 @@ pub fn draw_config_window(
 
             ui.separator();
             ui.heading(tr(lang, "BSP Limits", "Limity BSP"));
-            ui.add(egui::Slider::new(&mut cfg.max_bsp_depth, 1..=64).text(tr(lang, "Max depth", "Maximální hloubka")));
+            ui.add(egui::Slider::new(&mut cfg.max_bsp_depth, 1..=64).text(tr(
+                lang,
+                "Max depth",
+                "Maximální hloubka",
+            )));
             let max_depth = cfg.max_bsp_depth;
             ui.add(
-                egui::Slider::new(&mut cfg.default_branch_limit, 1..=max_depth)
-                    .text(tr(lang, "Default branch limit", "Výchozí limit větví")),
+                egui::Slider::new(&mut cfg.default_branch_limit, 1..=max_depth).text(tr(
+                    lang,
+                    "Default branch limit",
+                    "Výchozí limit větví",
+                )),
             );
             ui.add(
-                egui::Slider::new(&mut cfg.min_triangles_per_leaf, 1..=100)
-                    .text(tr(lang, "Min triangles per leaf", "Min trojúhelníků na list")),
+                egui::Slider::new(&mut cfg.min_triangles_per_leaf, 1..=100).text(tr(
+                    lang,
+                    "Min triangles per leaf",
+                    "Min trojúhelníků na list",
+                )),
             );
 
             ui.separator();
             ui.heading(tr(lang, "Camera", "Kamera"));
             if ui
-                .add(egui::Slider::new(&mut cam.speed, 0.1..=20.0).text(tr(lang, "Speed", "Rychlost")))
+                .add(
+                    egui::Slider::new(&mut cam.speed, 0.1..=20.0)
+                        .text(tr(lang, "Speed", "Rychlost")),
+                )
                 .changed()
             {
                 cfg.camera_speed = cam.speed;
             }
             if ui
-                .add(egui::Slider::new(&mut cam.look_speed, 0.1..=10.0).text(tr(lang, "Look speed", "Rychlost otáčení")))
+                .add(egui::Slider::new(&mut cam.look_speed, 0.1..=10.0).text(tr(
+                    lang,
+                    "Look speed",
+                    "Rychlost otáčení",
+                )))
                 .changed()
             {
                 cfg.look_speed = cam.look_speed;
             }
-            ui.add(egui::Slider::new(&mut cfg.default_fov_deg, 30.0..=120.0).text(tr(lang, "FOV deg", "FOV stupně")));
-            ui.add(egui::Slider::new(&mut cfg.near_plane, 0.01..=10.0).text(tr(lang, "Near plane", "Blízká rovina")));
-            ui.add(egui::Slider::new(&mut cfg.far_plane, 10.0..=5000.0).text(tr(lang, "Far plane", "Vzdálená rovina")));
+            ui.add(
+                egui::Slider::new(&mut cfg.default_fov_deg, 30.0..=120.0).text(tr(
+                    lang,
+                    "FOV deg",
+                    "FOV stupně",
+                )),
+            );
+            ui.add(egui::Slider::new(&mut cfg.near_plane, 0.01..=10.0).text(tr(
+                lang,
+                "Near plane",
+                "Blízká rovina",
+            )));
+            ui.add(
+                egui::Slider::new(&mut cfg.far_plane, 10.0..=5000.0).text(tr(
+                    lang,
+                    "Far plane",
+                    "Vzdálená rovina",
+                )),
+            );
 
             ui.separator();
             ui.heading(tr(lang, "Spectator", "Divák"));
             ui.checkbox(
                 show_spectator_marker,
-                tr(lang, "Show spectator position and direction", "Zobrazit pozici a směr diváka"),
+                tr(
+                    lang,
+                    "Show spectator position and direction",
+                    "Zobrazit pozici a směr diváka",
+                ),
             );
 
             ui.horizontal(|ui| {
@@ -288,13 +342,25 @@ pub fn draw_config_window(
                 }
             });
             ui.add(
-                egui::Slider::new(&mut cfg.camera_marker_scale, 0.01..=1.0)
-                    .text(tr(lang, "Marker scale", "Měřítko značky")),
+                egui::Slider::new(&mut cfg.camera_marker_scale, 0.01..=1.0).text(tr(
+                    lang,
+                    "Marker scale",
+                    "Měřítko značky",
+                )),
             );
             ui.add(
-                egui::Slider::new(&mut cfg.direction_ray_thickness, 0.01..=1.0)
-                    .text(tr(lang, "Ray thickness", "Tloušťka paprsku")),
+                egui::Slider::new(&mut cfg.direction_ray_thickness, 0.01..=1.0).text(tr(
+                    lang,
+                    "Ray thickness",
+                    "Tloušťka paprsku",
+                )),
             );
-            ui.add(egui::Slider::new(&mut cfg.direction_ray_length, 0.1..=10.0).text(tr(lang, "Ray length", "Délka paprsku")));
+            ui.add(
+                egui::Slider::new(&mut cfg.direction_ray_length, 0.1..=10.0).text(tr(
+                    lang,
+                    "Ray length",
+                    "Délka paprsku",
+                )),
+            );
         });
 }

--- a/src/gui/left_panel.rs
+++ b/src/gui/left_panel.rs
@@ -1,3 +1,5 @@
+//! Left-side control panel with file loading and visualization options.
+
 use crate::config::CONFIG;
 use cgmath::InnerSpace;
 use egui::{CollapsingHeader, Grid};

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,5 +1,7 @@
-pub mod tree;
+//! Egui-based user interface components.
+
 pub mod config;
 pub mod left_panel;
+pub mod tree;
 
 pub use left_panel::draw_left_panel;

--- a/src/gui/tree.rs
+++ b/src/gui/tree.rs
@@ -1,3 +1,5 @@
+//! BSP tree visualization window built with `egui_plot`.
+
 use crate::config::CONFIG;
 use egui_plot::{Line, Plot, PlotPoint, Points, Text};
 use std::collections::{HashMap, HashSet};
@@ -17,7 +19,10 @@ fn layout_bsp_tree(
     data: &mut TreePlotData,
 ) {
     let self_x = (x_min + x_max) / 2.0;
-    let self_point = PlotPoint { x: self_x, y: -depth };
+    let self_point = PlotPoint {
+        x: self_x,
+        y: -depth,
+    };
     data.positions.insert(node.id, self_point);
 
     if let Some(ref front) = node.front {
@@ -42,14 +47,19 @@ pub fn draw_bsp_tree_window(
         .vscroll(true)
         .hscroll(true)
         .show(ctx, |ui| {
-            let mut data = TreePlotData { positions: HashMap::new(), edges: Vec::new() };
+            let mut data = TreePlotData {
+                positions: HashMap::new(),
+                edges: Vec::new(),
+            };
             layout_bsp_tree(root, 0.0, 0.0, 1.0, &mut data);
 
             let mut path_ids = HashSet::new();
             if let Some(sel_id) = *selected {
                 let mut path = Vec::new();
                 if crate::bsp::find_node_path(root, sel_id, &mut path) {
-                    for n in path { path_ids.insert(n.id); }
+                    for n in path {
+                        path_ids.insert(n.id);
+                    }
                 }
             }
 
@@ -60,7 +70,8 @@ pub fn draw_bsp_tree_window(
             let plot = Plot::new("bsp_tree_plot");
             let plot_resp = plot.show(ui, |plot_ui| {
                 for &(a, b) in &data.edges {
-                    if let (Some(&p1), Some(&p2)) = (data.positions.get(&a), data.positions.get(&b)) {
+                    if let (Some(&p1), Some(&p2)) = (data.positions.get(&a), data.positions.get(&b))
+                    {
                         let pts = vec![[p1.x, p1.y], [p2.x, p2.y]];
                         let color = if path_ids.contains(&a) && path_ids.contains(&b) {
                             highlight_color
@@ -104,7 +115,9 @@ pub fn draw_bsp_tree_window(
                             best = Some(id);
                         }
                     }
-                    if let Some(id) = best { *selected = Some(id); }
+                    if let Some(id) = best {
+                        *selected = Some(id);
+                    }
                 }
             }
         });

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Input handling utilities
+//! Keyboard input handling and mapping to movement controls.
 
 use cgmath::InnerSpace;
 use cgmath::Vector3;

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,3 +1,5 @@
+//! Minimal two-language helper (English and Czech).
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Language {
     English,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,3 +1,5 @@
+//! GLTF/GLB mesh loading with basic validation and logging.
+
 use anyhow::Result;
 use log::{error, info, warn};
 use std::path::Path;
@@ -104,7 +106,11 @@ fn load_gltf_with_gltf_crate(path: &Path) -> Result<(CpuMesh, Option<CpuTexture>
         } else {
             Indices::U32(all_indices)
         },
-        uvs: if all_uvs.is_empty() { None } else { Some(all_uvs) },
+        uvs: if all_uvs.is_empty() {
+            None
+        } else {
+            Some(all_uvs)
+        },
         ..Default::default()
     };
     Ok((mesh, texture))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+//! Application entry point orchestrating rendering, input and BSP updates.
 // -----------------------------------------------------------------------------
 // BSP Viewer – minimální demo pro three‑d 0.18.x
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add Code Overview section to README
- index more functions and modules in FUNCTIONS.md
- document modules like `bsp`, `geometry`, and GUI components

## Testing
- `cargo fmt`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68b42cd2cca4832fb67aba84f9a05dfd