### PR TITLE
Synchronize branch limit slider across GUI panels

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -554,8 +554,15 @@ fn main() -> Result<()> {
         );
 
         if branch_limit != last_branch_limit {
+            // Update the default branch limit in the global configuration so that
+            // the slider in the configuration window stays in sync with the one in
+            // the left control panel.
+            CONFIG.write().unwrap().default_branch_limit = branch_limit;
+            last_default_branch_limit = branch_limit;
+
             let next_id = AtomicUsize::new(0);
-            bsp_root_preview = Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
+            bsp_root_preview =
+                Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
             selected_node = None;
             last_branch_limit = branch_limit;
         }


### PR DESCRIPTION
## Summary
- update global config when branch limit slider changes in left panel so config window reflects it

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b437e48880832f86acbb3cf1976a96

## Summary by Sourcery

Enhancements:
- Update global config default_branch_limit when the branch limit slider changes to keep panels in sync