### PR TITLE
Use built-in camera defaults for Home and add swap button

### DIFF
--- a/src/gui/config.rs
+++ b/src/gui/config.rs
@@ -259,6 +259,32 @@ pub fn draw_config_window(
                 ),
             );
 
+            if ui
+                .button(tr(
+                    lang,
+                    "Swap spectator and third person",
+                    "Prohodit diváka a třetí osobu",
+                ))
+                .clicked()
+            {
+                std::mem::swap(spectator_state, third_person_state);
+                if mode == crate::camera::CamMode::Spectator {
+                    cam.pos = spectator_state.pos;
+                    cam.yaw = spectator_state.yaw;
+                    cam.pitch = spectator_state.pitch;
+                } else if mode == crate::camera::CamMode::ThirdPerson {
+                    cam.pos = third_person_state.pos;
+                    cam.yaw = third_person_state.yaw;
+                    cam.pitch = third_person_state.pitch;
+                }
+                cfg.default_spectator_pos = spectator_state.pos;
+                cfg.default_spectator_yaw = spectator_state.yaw;
+                cfg.default_spectator_pitch = spectator_state.pitch;
+                cfg.default_third_person_pos = third_person_state.pos;
+                cfg.default_third_person_yaw = third_person_state.yaw;
+                cfg.default_third_person_pitch = third_person_state.pitch;
+            }
+
             ui.horizontal(|ui| {
                 ui.label(tr(lang, "Spectator pos", "Pozice diváka"));
                 let mut changed = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -565,8 +565,7 @@ fn main() -> Result<()> {
             last_default_branch_limit = branch_limit;
 
             let next_id = AtomicUsize::new(0);
-            bsp_root_preview =
-                Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
+            bsp_root_preview = Some(build_bsp(&current_triangles, 0, branch_limit, &next_id));
             selected_node = None;
             last_branch_limit = branch_limit;
         }
@@ -756,12 +755,14 @@ fn main() -> Result<()> {
 
         // Obsluha klávesy Home - návrat na výchozí pozici pro aktuální režim
         if input_manager.is_key_pressed(KeyCode::Home) {
+            // Always reset to the hard-coded defaults rather than values from the config UI
+            let defaults = crate::config::Config::default();
             if mode == CamMode::Spectator {
                 // Vytvoření nového stavu kamery s výchozí pozicí, ale aktuální rychlostí kamery
                 let mut reset_state = CameraState::new(
-                    cfg.default_spectator_pos,
-                    cfg.default_spectator_yaw,
-                    cfg.default_spectator_pitch,
+                    defaults.default_spectator_pos,
+                    defaults.default_spectator_yaw,
+                    defaults.default_spectator_pitch,
                 );
                 reset_state.speed = cam.speed; // Zachová aktuální rychlost
                 reset_state.apply_to_camera(&mut cam);
@@ -770,9 +771,9 @@ fn main() -> Result<()> {
                 // ThirdPerson
                 // Vytvoření nového stavu kamery s výchozí pozicí, ale aktuální rychlostí kamery
                 let mut reset_state = CameraState::new(
-                    cfg.default_third_person_pos,
-                    cfg.default_third_person_yaw,
-                    cfg.default_third_person_pitch,
+                    defaults.default_third_person_pos,
+                    defaults.default_third_person_yaw,
+                    defaults.default_third_person_pitch,
                 );
                 reset_state.speed = cam.speed; // Zachová aktuální rychlost
                 reset_state.apply_to_camera(&mut cam);


### PR DESCRIPTION
## Summary
- Reset Home key to always use hard-coded camera defaults
- Add config UI button to swap spectator and third-person camera positions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6caab2a00832f91ac18facbdc4bb5

## Summary by Sourcery

Use hard-coded camera defaults for the Home key reset and provide a UI control to swap spectator and third-person camera positions.

New Features:
- Add a configuration UI button to swap spectator and third-person camera presets

Enhancements:
- Change Home key behavior to use built-in camera defaults instead of user-modified config values