### PR TITLE
Add frustum plane visualization and unified camera teleport

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -38,7 +38,7 @@ source code so you can jump directly to the implementation.
 - [`triangle_center`](src/geometry.rs#L182-L184) – compute the centroid of a triangle.
 
 ## `src/gui/left_panel.rs`
-- [`draw_left_panel`](src/gui/left_panel.rs#L14-L490) – render the left control panel and handle UI interactions.
+- [`draw_left_panel`](src/gui/left_panel.rs#L14-L507) – render the left control panel and handle UI interactions.
 
 ## `src/gui/tree.rs`
 - [`layout_bsp_tree`](src/gui/tree.rs#L14-L33) – compute plot positions for BSP nodes.

--- a/src/gui/config.rs
+++ b/src/gui/config.rs
@@ -259,72 +259,41 @@ pub fn draw_config_window(
                 ),
             );
 
-            if ui
-                .button(tr(
+            let button_text = match mode {
+                crate::camera::CamMode::Spectator => tr(
                     lang,
-                    "Teleport third person to spectator",
-                    "Teleportovat třetí osobu k divákovi",
-                ))
-                .clicked()
-            {
-                third_person_state.pos = spectator_state.pos;
-                third_person_state.yaw = spectator_state.yaw;
-                third_person_state.pitch = spectator_state.pitch;
-                if mode == crate::camera::CamMode::ThirdPerson {
-                    cam.pos = third_person_state.pos;
-                    cam.yaw = third_person_state.yaw;
-                    cam.pitch = third_person_state.pitch;
+                    "Teleport to third person",
+                    "Teleportovat k třetí osobě",
+                ),
+                crate::camera::CamMode::ThirdPerson => {
+                    tr(lang, "Teleport to spectator", "Teleportovat k divákovi")
                 }
-                cfg.default_third_person_pos = third_person_state.pos;
-                cfg.default_third_person_yaw = third_person_state.yaw;
-                cfg.default_third_person_pitch = third_person_state.pitch;
-            }
-
-            if ui
-                .button(tr(
-                    lang,
-                    "Teleport spectator to third person",
-                    "Teleportovat diváka k třetí osobě",
-                ))
-                .clicked()
-            {
-                spectator_state.pos = third_person_state.pos;
-                spectator_state.yaw = third_person_state.yaw;
-                spectator_state.pitch = third_person_state.pitch;
-                if mode == crate::camera::CamMode::Spectator {
-                    cam.pos = spectator_state.pos;
-                    cam.yaw = spectator_state.yaw;
-                    cam.pitch = spectator_state.pitch;
+            };
+            if ui.button(button_text).clicked() {
+                match mode {
+                    crate::camera::CamMode::Spectator => {
+                        spectator_state.pos = third_person_state.pos;
+                        spectator_state.yaw = third_person_state.yaw;
+                        spectator_state.pitch = third_person_state.pitch;
+                        cam.pos = spectator_state.pos;
+                        cam.yaw = spectator_state.yaw;
+                        cam.pitch = spectator_state.pitch;
+                        cfg.default_spectator_pos = spectator_state.pos;
+                        cfg.default_spectator_yaw = spectator_state.yaw;
+                        cfg.default_spectator_pitch = spectator_state.pitch;
+                    }
+                    crate::camera::CamMode::ThirdPerson => {
+                        third_person_state.pos = spectator_state.pos;
+                        third_person_state.yaw = spectator_state.yaw;
+                        third_person_state.pitch = spectator_state.pitch;
+                        cam.pos = third_person_state.pos;
+                        cam.yaw = third_person_state.yaw;
+                        cam.pitch = third_person_state.pitch;
+                        cfg.default_third_person_pos = third_person_state.pos;
+                        cfg.default_third_person_yaw = third_person_state.yaw;
+                        cfg.default_third_person_pitch = third_person_state.pitch;
+                    }
                 }
-                cfg.default_spectator_pos = spectator_state.pos;
-                cfg.default_spectator_yaw = spectator_state.yaw;
-                cfg.default_spectator_pitch = spectator_state.pitch;
-            }
-
-            if ui
-                .button(tr(
-                    lang,
-                    "Swap spectator and third person",
-                    "Prohodit diváka a třetí osobu",
-                ))
-                .clicked()
-            {
-                std::mem::swap(spectator_state, third_person_state);
-                if mode == crate::camera::CamMode::Spectator {
-                    cam.pos = spectator_state.pos;
-                    cam.yaw = spectator_state.yaw;
-                    cam.pitch = spectator_state.pitch;
-                } else if mode == crate::camera::CamMode::ThirdPerson {
-                    cam.pos = third_person_state.pos;
-                    cam.yaw = third_person_state.yaw;
-                    cam.pitch = third_person_state.pitch;
-                }
-                cfg.default_spectator_pos = spectator_state.pos;
-                cfg.default_spectator_yaw = spectator_state.yaw;
-                cfg.default_spectator_pitch = spectator_state.pitch;
-                cfg.default_third_person_pos = third_person_state.pos;
-                cfg.default_third_person_yaw = third_person_state.yaw;
-                cfg.default_third_person_pitch = third_person_state.pitch;
             }
 
             ui.horizontal(|ui| {

--- a/src/gui/left_panel.rs
+++ b/src/gui/left_panel.rs
@@ -27,6 +27,7 @@ pub fn draw_left_panel(
     selected_node: &mut Option<usize>,
     show_splitting_plane: &mut bool,
     disable_culling: &mut bool,
+    show_fov_plane: &mut bool,
     show_loaded_model: &mut bool,
     show_selected_model: &mut bool,
     show_texture: &mut bool,
@@ -93,7 +94,8 @@ pub fn draw_left_panel(
                             *current_texture = None;
                             *current_texture = Some(Texture2DRef::from_cpu_texture(gl, &tex));
                             *show_texture = true;
-                            *loaded_texture_name = path.file_name().unwrap().to_string_lossy().into_owned();
+                            *loaded_texture_name =
+                                path.file_name().unwrap().to_string_lossy().into_owned();
                         }
                         Err(e) => {
                             error!("Failed to load texture {}: {}", path.display(), e);
@@ -220,6 +222,10 @@ pub fn draw_left_panel(
                 tr(lang, "Disable culling", "Zakázat culling"),
             );
             ui.checkbox(
+                show_fov_plane,
+                tr(lang, "Show frustum plane", "Zobrazit rovinu zorného pole"),
+            );
+            ui.checkbox(
                 show_loaded_model,
                 tr(lang, "Show loaded model", "Zobrazit načtený model"),
             );
@@ -305,10 +311,26 @@ pub fn draw_left_panel(
                 ));
             });
             CollapsingHeader::new(tr(lang, "Looking around", "Rozhlížení")).show(ui, |ui| {
-                ui.label(tr(lang, "Arrow UP - Look up", "Šipka Nahoru - dívat se nahoru"));
-                ui.label(tr(lang, "Arrow DOWN - Look down", "Šipka Dolů - dívat se dolů"));
-                ui.label(tr(lang, "Arrow LEFT - Turn left", "Šipka vlevo - otočit doleva"));
-                ui.label(tr(lang, "Arrow RIGHT - Turn right", "Šipka vpravo - otočit doprava"));
+                ui.label(tr(
+                    lang,
+                    "Arrow UP - Look up",
+                    "Šipka Nahoru - dívat se nahoru",
+                ));
+                ui.label(tr(
+                    lang,
+                    "Arrow DOWN - Look down",
+                    "Šipka Dolů - dívat se dolů",
+                ));
+                ui.label(tr(
+                    lang,
+                    "Arrow LEFT - Turn left",
+                    "Šipka vlevo - otočit doleva",
+                ));
+                ui.label(tr(
+                    lang,
+                    "Arrow RIGHT - Turn right",
+                    "Šipka vpravo - otočit doprava",
+                ));
                 // ui.label(format!(
                 //     "{}: {:.1}°/s",
                 //     tr(lang, "Look speed", "Rychlost otáčení"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,59 @@ fn create_visible_mesh(
     Gm::new(Mesh::new(context, &visible_mesh), material)
 }
 
+fn create_fov_plane_mesh(
+    cam: &FreeCamera,
+    viewport: Viewport,
+    context: &Context,
+) -> Gm<Mesh, ColorMaterial> {
+    let cfg = CONFIG.read().unwrap();
+    let d = cfg.near_plane;
+    let aspect = viewport.width as f32 / viewport.height as f32;
+    let fov = cfg.default_fov_deg.to_radians();
+    let height = 2.0 * d * (fov * 0.5).tan();
+    let width = height * aspect;
+
+    let dir = cam.dir();
+    let right = cam.right();
+    let up = right.cross(dir).normalize();
+
+    let center = cam.pos + dir * d;
+    let u = right * (width * 0.5);
+    let v = up * (height * 0.5);
+    let corners = [
+        center + u + v,
+        center + u - v,
+        center - u - v,
+        center - u + v,
+    ];
+
+    let positions = vec![
+        vec3(corners[0].x, corners[0].y, corners[0].z),
+        vec3(corners[1].x, corners[1].y, corners[1].z),
+        vec3(corners[2].x, corners[2].y, corners[2].z),
+        vec3(corners[3].x, corners[3].y, corners[3].z),
+    ];
+    let indices = vec![0, 1, 2, 2, 3, 0];
+
+    let cpu_mesh = CpuMesh {
+        positions: Positions::F32(positions),
+        indices: Indices::U32(indices),
+        ..Default::default()
+    };
+
+    let cpu_material = CpuMaterial {
+        albedo: cfg.splitting_plane_color,
+        ..Default::default()
+    };
+    let material = if cfg.splitting_plane_color.a < 255 {
+        ColorMaterial::new_transparent(context, &cpu_material)
+    } else {
+        ColorMaterial::new_opaque(context, &cpu_material)
+    };
+
+    Gm::new(Mesh::new(context, &cpu_mesh), material)
+}
+
 // ---------------- Main --------------------------------------------------- //
 
 fn main() -> Result<()> {
@@ -252,6 +305,7 @@ fn main() -> Result<()> {
     };
 
     let mut disable_culling = false;
+    let mut show_fov_plane = false;
     let mut show_loaded_model = true;
     let mut show_selected_model = true;
     let mut tree_window_open = false;
@@ -540,6 +594,7 @@ fn main() -> Result<()> {
                     &mut selected_node,
                     &mut show_splitting_plane,
                     &mut disable_culling,
+                    &mut show_fov_plane,
                     &mut show_loaded_model,
                     &mut show_selected_model,
                     &mut show_texture,
@@ -989,6 +1044,14 @@ fn main() -> Result<()> {
         }
         if let Some(ref plane_mesh) = splitting_plane_mesh {
             objects_to_render.push(plane_mesh);
+        }
+
+        let mut fov_plane_mesh = None;
+        if show_fov_plane {
+            fov_plane_mesh = Some(create_fov_plane_mesh(&cam, frame_input.viewport, &context));
+        }
+        if let Some(ref plane) = fov_plane_mesh {
+            objects_to_render.push(plane);
         }
         if show_spectator_marker && mode == CamMode::ThirdPerson {
             objects_to_render.push(&spectator_glow);


### PR DESCRIPTION
## Summary
- Replace three teleport buttons with one that switches between spectator and third person
- Allow toggling a frustum plane overlay from the display settings
- Render a camera field-of-view plane when enabled

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d42539a8832fa4d9a466edca5653

## Summary by Sourcery

Unify camera teleport controls into one context-aware button and add a display setting to visualize the camera frustum plane by rendering the FOV near-plane mesh

New Features:
- Add a unified teleport button that switches between spectator and third-person camera positions
- Introduce a toggle in the display settings for showing the camera frustum plane overlay
- Render the camera field-of-view plane mesh when the frustum overlay is enabled

Enhancements:
- Refactor teleport UI logic to use a single context-aware button instead of separate teleport and swap buttons

Documentation:
- Update FUNCTIONS.md to reflect expanded draw_left_panel documentation range