### PR TITLE
Unify spectator/third-person teleport button

### DIFF
--- a/src/gui/config.rs
+++ b/src/gui/config.rs
@@ -262,43 +262,35 @@ pub fn draw_config_window(
             if ui
                 .button(tr(
                     lang,
-                    "Teleport third person to spectator",
-                    "Teleportovat třetí osobu k divákovi",
+                    "Teleport to other camera",
+                    "Teleportovat na druhou kameru",
                 ))
                 .clicked()
             {
-                third_person_state.pos = spectator_state.pos;
-                third_person_state.yaw = spectator_state.yaw;
-                third_person_state.pitch = spectator_state.pitch;
-                if mode == crate::camera::CamMode::ThirdPerson {
-                    cam.pos = third_person_state.pos;
-                    cam.yaw = third_person_state.yaw;
-                    cam.pitch = third_person_state.pitch;
+                match mode {
+                    crate::camera::CamMode::Spectator => {
+                        spectator_state.pos = third_person_state.pos;
+                        spectator_state.yaw = third_person_state.yaw;
+                        spectator_state.pitch = third_person_state.pitch;
+                        cam.pos = spectator_state.pos;
+                        cam.yaw = spectator_state.yaw;
+                        cam.pitch = spectator_state.pitch;
+                        cfg.default_spectator_pos = spectator_state.pos;
+                        cfg.default_spectator_yaw = spectator_state.yaw;
+                        cfg.default_spectator_pitch = spectator_state.pitch;
+                    }
+                    crate::camera::CamMode::ThirdPerson => {
+                        third_person_state.pos = spectator_state.pos;
+                        third_person_state.yaw = spectator_state.yaw;
+                        third_person_state.pitch = spectator_state.pitch;
+                        cam.pos = third_person_state.pos;
+                        cam.yaw = third_person_state.yaw;
+                        cam.pitch = third_person_state.pitch;
+                        cfg.default_third_person_pos = third_person_state.pos;
+                        cfg.default_third_person_yaw = third_person_state.yaw;
+                        cfg.default_third_person_pitch = third_person_state.pitch;
+                    }
                 }
-                cfg.default_third_person_pos = third_person_state.pos;
-                cfg.default_third_person_yaw = third_person_state.yaw;
-                cfg.default_third_person_pitch = third_person_state.pitch;
-            }
-
-            if ui
-                .button(tr(
-                    lang,
-                    "Teleport spectator to third person",
-                    "Teleportovat diváka k třetí osobě",
-                ))
-                .clicked()
-            {
-                spectator_state.pos = third_person_state.pos;
-                spectator_state.yaw = third_person_state.yaw;
-                spectator_state.pitch = third_person_state.pitch;
-                if mode == crate::camera::CamMode::Spectator {
-                    cam.pos = spectator_state.pos;
-                    cam.yaw = spectator_state.yaw;
-                    cam.pitch = spectator_state.pitch;
-                }
-                cfg.default_spectator_pos = spectator_state.pos;
-                cfg.default_spectator_yaw = spectator_state.yaw;
-                cfg.default_spectator_pitch = spectator_state.pitch;
             }
 
             if ui


### PR DESCRIPTION
## Summary
- Replace separate teleport buttons with a single "Teleport to other camera" action
- Mirror previous teleport behavior depending on active camera mode

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6dd148ee8832f9985c3bbf419b7b1

## Summary by Sourcery

Unify spectator and third-person teleport functionality into a single context-sensitive action

Enhancements:
- Replace separate spectator and third-person teleport buttons with one “Teleport to other camera” button
- Match on the active camera mode to mirror position, orientation, and defaults accordingly